### PR TITLE
fixed logging message

### DIFF
--- a/run/archiveloop
+++ b/run/archiveloop
@@ -135,7 +135,7 @@ function ensure_cam_file_is_mounted () {
 function ensure_music_file_is_mounted () {
   log "Ensuring music backing file is mounted..."
   ensure_mountpoint_is_mounted_with_retry "$MUSIC_MOUNT"
-  log "Ensured cam drive is mounted."
+  log "Ensured music drive is mounted."
 }
 
 function unmount_mount_point () {


### PR DESCRIPTION
log message in ensure_music_file_is_mounted() was copied and pasted from ensure_cam_file_is_mounted() but not changed to say MUSIC instead of CAM