### PR TITLE
*.conf files won't sync upstream by mistake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+*.conf


### PR DESCRIPTION
This changes the .gitignore so that *.conf won't sync upstream by mistake, preventing potential security issues.  