### PR TITLE
Additional fixes to rsync version of archive-clips

### DIFF
--- a/run/rsync_archive/archive-clips.sh
+++ b/run/rsync_archive/archive-clips.sh
@@ -8,7 +8,7 @@ num_files_moved=$(rsync -auvh --remove-source-files --no-perms --stats --log-fil
 
 /root/bin/send-push-message "$num_files_moved"
 
-if [ $num_files_moved > 0 ]
+if (( $num_files_moved > 0 ))
 then
   find /mnt/cam/Teslacam/SavedClips/ -depth -type d -empty -exec rmdir "{}" \;
   log "Successfully synced files through rsync."


### PR DESCRIPTION
Was not performing correct integer comparison, so code was never executed