### PR TITLE
Added timeout to rsync

### DIFF
--- a/run/rsync_archive/archive-clips.sh
+++ b/run/rsync_archive/archive-clips.sh
@@ -4,7 +4,7 @@ log "Archiving through rsync..."
 
 source /root/.teslaCamRsyncConfig
 
-num_files_moved=$(rsync -auvh --remove-source-files --no-perms --stats --log-file=/tmp/archive-rsync-cmd.log $CAM_MOUNT/TeslaCam/saved* $CAM_MOUNT/TeslaCam/SavedClips/* $user@$server:$path | awk '/files transferred/{print $NF}')
+num_files_moved=$(rsync -auvh --timeout=120 --remove-source-files --no-perms --stats --log-file=/tmp/archive-rsync-cmd.log $CAM_MOUNT/TeslaCam/saved* $CAM_MOUNT/TeslaCam/SavedClips/* $user@$server:$path | awk '/files transferred/{print $NF}')
 
 /root/bin/send-push-message "$num_files_moved"
 


### PR DESCRIPTION
Added a timeout of 120s for rsync to abort. This should take care of cases where rsync is in progress and the wifi is lost. 