### PR TITLE
moved tesla_api.py to be called from archiveloop

### DIFF
--- a/run/archiveloop
+++ b/run/archiveloop
@@ -251,8 +251,24 @@ function archive_teslacam_clips () {
 
   fix_errors_in_cam_file
 
+  if [ -f /root/bin/tesla_api.py ]
+  then
+    while :
+    do
+      sleep 120
+      /root/bin/tesla_api.py wake_up_vehicle >> "$LOG_FILE"
+    done&
+    WAKE_PID=$!
+    log "wake up car process is $WAKE_PID"
+  fi
+
   /root/bin/archive-clips.sh
 
+  if [ ! -z "${WAKE_PID+x}" ]
+  then
+    log "killing PID $WAKE_PID"
+    kill $WAKE_PID
+  fi
   unmount_cam_file
 }
 

--- a/run/cifs_archive/archive-clips.sh
+++ b/run/cifs_archive/archive-clips.sh
@@ -17,9 +17,6 @@ function keep_car_awake() {
 function moveclips() {
   ROOT="$1"
   PATTERN="$2"
-  # Set the Bash variable "SECONDS" to 0, so we can count how long we've been
-  # archiving, for Tesla API purposes.
-  SECONDS=0
 
   if [ ! -d "$ROOT" ]
   then
@@ -52,16 +49,6 @@ function moveclips() {
         then
           log "Moved '$file_name'"
           NUM_FILES_MOVED=$((NUM_FILES_MOVED + 1))
-
-          # Every 5 minutes, send a wakeup command to the car via the Tesla API,
-          # to keep the Pi powered.
-          if (( $SECONDS / 300 > 0 ))
-          then
-              # Prevent failures of the API script from killing the archive loop.
-              keep_car_awake || true
-              # Reset the timer, so our 5 minute math will work for the next go-round.
-              SECONDS=0
-          fi
         else
           log "Failed to move '$file_name'"
           NUM_FILES_FAILED=$((NUM_FILES_FAILED + 1))

--- a/run/rsync_archive/archive-clips.sh
+++ b/run/rsync_archive/archive-clips.sh
@@ -4,7 +4,7 @@ log "Archiving through rsync..."
 
 source /root/.teslaCamRsyncConfig
 
-num_files_moved=$(rsync -auvh --remove-source-files --no-perms --stats --log-file=/tmp/archive-rsync-cmd.log $CAM_MOUNT/TeslaCam/saved* $CAM_MOUNT/TeslaCam/SavedClips/* $user@$server:$path | awk '/files transferred/{print $NF}')
+num_files_moved=$(rsync -auvh --timeout=45 --remove-source-files --no-perms --stats --log-file=/tmp/archive-rsync-cmd.log $CAM_MOUNT/TeslaCam/saved* $CAM_MOUNT/TeslaCam/SavedClips/* $user@$server:$path | awk '/files transferred/{print $NF}')
 
 /root/bin/send-push-message "$num_files_moved"
 

--- a/run/rsync_archive/archive-clips.sh
+++ b/run/rsync_archive/archive-clips.sh
@@ -5,11 +5,12 @@ log "Archiving through rsync..."
 source /root/.teslaCamRsyncConfig
 
 num_files_moved=$(rsync -auvh --timeout=45 --remove-source-files --no-perms --stats --log-file=/tmp/archive-rsync-cmd.log $CAM_MOUNT/TeslaCam/saved* $CAM_MOUNT/TeslaCam/SavedClips/* $user@$server:$path | awk '/files transferred/{print $NF}')
+
 /root/bin/send-push-message "$num_files_moved"
 
 if (( $num_files_moved > 0 ))
 then
-  find $CAM_MOUNT/TeslaCam/SavedClips -depth -type d -empty -delete
+  find $CAM_MOUNT/Teslacam/SavedClips/ -depth -type d -empty -exec rmdir "{}" \;
   log "Successfully synced files through rsync."
 else
   log "No files to archive through rsync."

--- a/run/rsync_archive/archive-clips.sh
+++ b/run/rsync_archive/archive-clips.sh
@@ -5,7 +5,6 @@ log "Archiving through rsync..."
 source /root/.teslaCamRsyncConfig
 
 num_files_moved=$(rsync -auvh --timeout=45 --remove-source-files --no-perms --stats --log-file=/tmp/archive-rsync-cmd.log $CAM_MOUNT/TeslaCam/saved* $CAM_MOUNT/TeslaCam/SavedClips/* $user@$server:$path | awk '/files transferred/{print $NF}')
-log "Deleting empty directories from SavedClips"
 /root/bin/send-push-message "$num_files_moved"
 
 if (( $num_files_moved > 0 ))

--- a/run/rsync_archive/archive-clips.sh
+++ b/run/rsync_archive/archive-clips.sh
@@ -5,12 +5,12 @@ log "Archiving through rsync..."
 source /root/.teslaCamRsyncConfig
 
 num_files_moved=$(rsync -auvh --timeout=45 --remove-source-files --no-perms --stats --log-file=/tmp/archive-rsync-cmd.log $CAM_MOUNT/TeslaCam/saved* $CAM_MOUNT/TeslaCam/SavedClips/* $user@$server:$path | awk '/files transferred/{print $NF}')
-
+log "Deleting empty directories from SavedClips"
 /root/bin/send-push-message "$num_files_moved"
 
 if (( $num_files_moved > 0 ))
 then
-  find $CAM_MOUNT/Teslacam/SavedClips/ -depth -type d -empty -exec rmdir "{}" \;
+  find $CAM_MOUNT/TeslaCam/SavedClips -depth -type d -empty -delete
   log "Successfully synced files through rsync."
 else
   log "No files to archive through rsync."


### PR DESCRIPTION
Moved the tesla wake up to archiveloop, so that it works for rsync. I can't test cifs, since I don't use it, but made the changes. This approach runs a loop in the background for the wakeup command, while archive-clips.sh is running, and then kills the PID once it returns. Also made a small change to make rsync timeout. Default is infinite, which causes the usb to not dismount if I leave home while rsync is running.