### PR TITLE
Update to correct configure_archive function

### DIFF
--- a/run/rclone_archive/verify-and-configure-archive.sh
+++ b/run/rclone_archive/verify-and-configure-archive.sh
@@ -26,7 +26,8 @@ function configure_archive () {
   if [ ! -L "/root/.config/rclone" ] && [ -e "/root/.config/rclone" ]
   then
     echo "Moving rclone configs into /mutable"
-    mv /root/.config/rclone /mutable/configs
+    mkdir -p /mutable/configs/rclone
+    mv /root/.config/rclone/rclone.conf /mutable/configs/rclone/
     ln -s /mutable/configs/rclone /root/.config/rclone
   fi
 


### PR DESCRIPTION
- Added "mkdir -p /mutable/configs/rclone" as this directory did not exist at the time of the first call
- Changed "mv /root/.config/rclone /mutable/configs" to "mv /root/.config/rclone/rclone.conf /mutable/configs/rclone/" to match ln in next line