### PR TITLE
Start/stop ntp process to force time set

### DIFF
--- a/run/archiveloop
+++ b/run/archiveloop
@@ -385,10 +385,14 @@ function set_time () {
     sleep 2
   done
   log "Time still not set, attempting to force it"
+  log "Stopping ntp process ..."
+    /etc/init.d/ntp stop
   if ! ntpd -q -x -g
   then
     log "Failed to set time"
   fi
+  log "Starting ntp process ..."
+    /etc/init.d/ntp start
 }
 
 export ARCHIVE_HOST_NAME


### PR DESCRIPTION
Found that in order for "ntpd -q -x -p" check to work the ntp process needed to be stopped first. The ntp process then needed to be restarted. Added logging and stop/start commands.