### PR TITLE
Fix force setting time

### DIFF
--- a/run/archiveloop
+++ b/run/archiveloop
@@ -385,10 +385,12 @@ function set_time () {
     sleep 2
   done
   log "Time still not set, attempting to force it"
+  systemctl stop ntp
   if ! ntpd -q -x -g
   then
     log "Failed to set time"
   fi
+  systemctl start ntp
 }
 
 export ARCHIVE_HOST_NAME

--- a/run/archiveloop
+++ b/run/archiveloop
@@ -385,12 +385,18 @@ function set_time () {
     sleep 2
   done
   log "Time still not set, attempting to force it"
-  systemctl stop ntp
+  if ! systemctl stop ntp
+  then
+    log "Failed to stop ntp daemon"
+  fi
   if ! ntpd -q -x -g
   then
     log "Failed to set time"
   fi
-  systemctl start ntp
+  if ! systemctl start ntp
+  then
+    log "Failed to start ntp daemon"
+  fi
 }
 
 export ARCHIVE_HOST_NAME


### PR DESCRIPTION
With newer raspbian, the force time set won't work because it interferes with the listening port that ntpd uses. This stops ntp and starts ntp before and after the force time set