### PR TITLE
Fix rclone move command

### DIFF
--- a/run/rclone_archive/archive-clips.sh
+++ b/run/rclone_archive/archive-clips.sh
@@ -4,20 +4,15 @@ log "Moving clips to rclone archive..."
 
 source /root/.teslaCamRcloneConfig
 
-NUM_FILES_MOVED=0
+FILE_COUNT=$(find "$CAM_MOUNT"/TeslaCam/SavedClips/* -type f | wc -l)
 
-for file_name in "$CAM_MOUNT"/TeslaCam/saved* "$CAM_MOUNT"/TeslaCam/SavedClips/*; do
-  [ -e "$file_name" ] || continue
-  log "Moving $file_name ..."
-  rclone --config /root/.config/rclone/rclone.conf move "$file_name" "$drive:$path" >> "$LOG_FILE" 2>&1 || echo ""
-  log "Moved $file_name."
-  NUM_FILES_MOVED=$((NUM_FILES_MOVED + 1))
-done
+rclone --config /root/.config/rclone/rclone.conf move "$CAM_MOUNT"/TeslaCam/SavedClips "$drive:$path" --create-empty-src-dirs --delete-empty-src-dirs >> "$LOG_FILE" 2>&1 || echo ""
+
+FILES_REMAINING=$(find "$CAM_MOUNT"/TeslaCam/SavedClips/* -type f | wc -l)
+NUM_FILES_MOVED=$((FILE_COUNT-FILES_REMAINING))
+
 log "Moved $NUM_FILES_MOVED file(s)."
+/root/bin/send-push-message "TeslaUSB:" "Moved $NUM_FILES_MOVED dashcam file(s)."
 
-if [ $NUM_FILES_MOVED -gt 0 ]
-then
-  /root/bin/send-push-message "TeslaUSB:" "Moved $NUM_FILES_MOVED dashcam file(s)."
-fi
 
 log "Finished moving clips to rclone archive"


### PR DESCRIPTION
Ok hopefully this is a better start:

Removed for loop and running a single move command on the SavedClips directory. Rclone docs explain that a move command moves the contents of the source directory, not the source directory itself.
Also getting file count for push notification, instead of directory count. This only works with Tesla firmware since 2019.5...