### PR TITLE
Update rclone archive-clips.sh

### DIFF
--- a/run/rclone_archive/archive-clips.sh
+++ b/run/rclone_archive/archive-clips.sh
@@ -4,15 +4,51 @@ log "Moving clips to rclone archive..."
 
 source /root/.teslaCamRcloneConfig
 
-FILE_COUNT=$(find "$CAM_MOUNT"/TeslaCam/SavedClips/* -type f | wc -l)
+NUM_FILES=0
+NUM_FILES_MOVED=0
+NUM_FILES_IN_DIR=0
 
-rclone --config /root/.config/rclone/rclone.conf move "$CAM_MOUNT"/TeslaCam/SavedClips "$drive:$path" --create-empty-src-dirs --delete-empty-src-dirs >> "$LOG_FILE" 2>&1 || echo ""
+function connectionmonitor {
+  while true
+  do
+    if timeout 5 /root/bin/archive-is-reachable.sh $ARCHIVE_HOST_NAME
+    then
+      sleep 2
+    elif timeout 5 /root/bin/archive-is-reachable.sh $ARCHIVE_HOST_NAME # try one more time
+    then
+      sleep 2
+    else
+      log "connection dead, killing archive-clips"
+      # The network connection may have been lost, so kill it hard.
+      # (should be no worse than losing power in the middle of an operation)
+      kill -9 $1
+      return
+    fi
+  done
+}
 
-FILES_REMAINING=$(find "$CAM_MOUNT"/TeslaCam/SavedClips/* -type f | wc -l)
-NUM_FILES_MOVED=$((FILE_COUNT-FILES_REMAINING))
+function moveclips() {
+  #rclone doesn't remove folders after moving files. This deletes empty directories
+  find "$CAM_MOUNT"/TeslaCam/SavedClips/ -type d -empty -delete
 
-log "Moved $NUM_FILES_MOVED file(s)."
-/root/bin/send-push-message "TeslaUSB:" "Moved $NUM_FILES_MOVED dashcam file(s)."
+  for file_name in "$CAM_MOUNT"/TeslaCam/saved* "$CAM_MOUNT"/TeslaCam/SavedClips/*; do
+    [ -e "$file_name" ] || continue
+	NUM_FILES_IN_DIR=$(ls "$file_name" | wc -l)
+    log "Moving $file_name ..."
+    rclone --config /root/.config/rclone/rclone.conf move "$file_name" "$drive:$path" >> "$LOG_FILE" 2>&1 || echo ""
+    log "Moved $file_name."
+    NUM_FILES_MOVED=$((NUM_FILES_MOVED + NUM_FILES_IN_DIR))
+	log "Moved $NUM_FILES_IN_DIR file(s)."
+  done
+  log "Done moving $NUM_FILES_MOVED file(s)."
+}
 
+connectionmonitor $$ &
+moveclips
+
+if [ $NUM_FILES_MOVED -gt 0 ]
+then
+  /root/bin/send-push-message "TeslaUSB:" "Moved $NUM_FILES_MOVED dashcam file(s)."
+fi
 
 log "Finished moving clips to rclone archive"


### PR DESCRIPTION
Killing connection if connection becomes unavailable.
Better logging for number of files moved. Previously was only counting folders.
Removal of empty directories, as rclone does not remove directories after moving files.