### PR TITLE
Sentry mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .DS_Store
 *.conf
+*.iml
+*.ipr
+*.iws

--- a/run/archiveloop
+++ b/run/archiveloop
@@ -266,43 +266,42 @@ function disconnect_usb_drives_from_host () {
 }
 
 function archive_teslacam_clips () {
-  log "Checking saved folder count..."
+    log "Checking saved folder count..."
   
-  ensure_cam_file_is_mounted
+    ensure_cam_file_is_mounted
 
-  fix_errors_in_cam_file
+    fix_errors_in_cam_file
   
-  DIR_COUNT=$(find "$CAM_MOUNT"/TeslaCam/SavedClips/* -maxdepth 0 -type d | wc -l)
-  FILE_COUNT=$(find "$CAM_MOUNT"/TeslaCam/SavedClips/* -type f | wc -l)
+    DIR_COUNT=$(find "$CAM_MOUNT"/TeslaCam/SavedClips/* -maxdepth 0 -type d | wc -l)
+    FILE_COUNT=$(find "$CAM_MOUNT"/TeslaCam/SavedClips/* -type f | wc -l)
   
-  log "There are $DIR_COUNT event folder(s) with $FILE_COUNT file(s) to move."
+    log "There are $DIR_COUNT event folder(s) with $FILE_COUNT file(s) to move."
   
-  if [ $DIR_COUNT -gt 0 ]
-  then
-	log "Starting recording archiving..."
+    if [ $DIR_COUNT -gt 0 ]; then
+        log "Starting recording archiving..."
 
-	/root/bin/send-push-message "TeslaUSB:" "Archiving $DIR_COUNT event folder(s) with $FILE_COUNT file(s) starting at $(date)"
+        /root/bin/send-push-message "TeslaUSB:" "Archiving $DIR_COUNT event folder(s) with $FILE_COUNT file(s) starting at $(date)"
 
-	if [ -f /root/bin/tesla_api.py ]
-	then
-		while :
-		do
-		sleep 120
-		/root/bin/tesla_api.py wake_up_vehicle &>> "$LOG_FILE"
-		done&
-		WAKE_PID=$!
-		log "wake up car process is $WAKE_PID"
-	fi
+        # Ensure Sentry Mode is enabled before archiving
+        declare is_sentry_mode_enabled
+        if [ -x /root/bin/tesla_api.py ]; then
+            is_sentry_mode_enabled=$(/root/bin/tesla_api.py is_sentry_mode_enabled)
+            if [ "false" = "${is_sentry_mode_enabled}" ]; then
+                log "Temporarily enabling Sentry Mode to power the RPi while archive job completes..."
+                /root/bin/tesla_api.py enable_sentry_mode &>> ${LOG_FILE}
+            fi
+        fi
 
-	/root/bin/archive-clips.sh
-	
-  fi
-  if [ ! -z "${WAKE_PID+x}" ]
-  then
-    log "killing PID $WAKE_PID"
-    kill $WAKE_PID
-  fi
-  unmount_cam_file
+        /root/bin/archive-clips.sh
+
+        # If Sentry Mode was previously disabled, restore it to that state
+        if [ "false" = "${is_sentry_mode_enabled}" ]; then
+            log "Restoring Sentry Mode to its previous state (disabled)..."
+            /root/bin/tesla_api.py disable_sentry_mode &>> ${LOG_FILE}
+        fi
+    fi
+
+    unmount_cam_file
 }
 
 function copy_music_files () {

--- a/run/archiveloop
+++ b/run/archiveloop
@@ -288,7 +288,7 @@ function archive_teslacam_clips () {
 		while :
 		do
 		sleep 120
-		/root/bin/tesla_api.py wake_up_vehicle >> "$LOG_FILE"
+		/root/bin/tesla_api.py wake_up_vehicle &>> "$LOG_FILE"
 		done&
 		WAKE_PID=$!
 		log "wake up car process is $WAKE_PID"

--- a/run/archiveloop
+++ b/run/archiveloop
@@ -277,16 +277,19 @@ function archive_teslacam_clips () {
   
     log "There are $DIR_COUNT event folder(s) with $FILE_COUNT file(s) to move."
   
-    if [ $DIR_COUNT -gt 0 ]; then
+    if [ $DIR_COUNT -gt 0 ]
+    then
         log "Starting recording archiving..."
 
         /root/bin/send-push-message "TeslaUSB:" "Archiving $DIR_COUNT event folder(s) with $FILE_COUNT file(s) starting at $(date)"
 
         # Ensure Sentry Mode is enabled before archiving
         declare is_sentry_mode_enabled
-        if [ -x /root/bin/tesla_api.py ]; then
+        if [ -x /root/bin/tesla_api.py ]
+        then
             is_sentry_mode_enabled=$(/root/bin/tesla_api.py is_sentry_mode_enabled)
-            if [ "false" = "${is_sentry_mode_enabled}" ]; then
+            if [ "false" = "${is_sentry_mode_enabled}" ]
+            then
                 log "Temporarily enabling Sentry Mode to power the RPi while archive job completes..."
                 /root/bin/tesla_api.py enable_sentry_mode &>> ${LOG_FILE}
             fi
@@ -295,7 +298,8 @@ function archive_teslacam_clips () {
         /root/bin/archive-clips.sh
 
         # If Sentry Mode was previously disabled, restore it to that state
-        if [ "false" = "${is_sentry_mode_enabled}" ]; then
+        if [ "false" = "${is_sentry_mode_enabled}" ]
+        then
             log "Restoring Sentry Mode to its previous state (disabled)..."
             /root/bin/tesla_api.py disable_sentry_mode &>> ${LOG_FILE}
         fi

--- a/run/cifs_archive/archive-clips.sh
+++ b/run/cifs_archive/archive-clips.sh
@@ -10,7 +10,7 @@ function keep_car_awake() {
   # If the tesla_api.py script is installed, send the car a wake_up command.
   if [ -f /root/bin/tesla_api.py ]
   then
-    /root/bin/tesla_api.py wake_up_vehicle >> "$LOG_FILE"
+    /root/bin/tesla_api.py wake_up_vehicle &>> "$LOG_FILE"
   fi
 }
 

--- a/run/cifs_archive/archive-clips.sh
+++ b/run/cifs_archive/archive-clips.sh
@@ -6,14 +6,6 @@ NUM_FILES_MOVED=0
 NUM_FILES_FAILED=0
 NUM_FILES_DELETED=0
 
-function keep_car_awake() {
-  # If the tesla_api.py script is installed, send the car a wake_up command.
-  if [ -f /root/bin/tesla_api.py ]
-  then
-    /root/bin/tesla_api.py wake_up_vehicle &>> "$LOG_FILE"
-  fi
-}
-
 function connectionmonitor {
   while true
   do


### PR DESCRIPTION
This should address gh-232.

`archiveloop` relies on the `wake_up_vehicle` REST command to keep the vehicle's USB port powered, but `wake_up_vehicle` does not seem to power to the USB port (maybe this used to work, but it no longer does as of Summer 2019).  As a result, the vehicle often powers down the USB port, cutting off power to the RPi before archiving has completed.

This PR makes several changes-
1. Added Sentry Mode commands to `tesla_api.py`
2. Changed `tesla_api.py` to ensure the vehicle is online/awake before sending commands to it.  Otherwise, most vehicle-specific commands fail when the vehicle is offline.
3. Changed `archiveloop` to stop calling `wake_up_vehicle` and instead temporarily enable Sentry Mode if it is not already enabled.  This powers the USB port and allows archiving to complete.  Sentry Mode is disabled after archiving if it was enabled by `archiveloop`
4. Removed `keep_car_awake` function from `cifs_archive/archive-clips.sh` because it did not appear to be used

Let me know if you need this rebased, the commits squashed, or have any questions.  Testing on my MX has been promising, but this could definitely benefit from additional testing from others.