### PR TITLE
Streamline set_time function

### DIFF
--- a/run/archiveloop
+++ b/run/archiveloop
@@ -388,16 +388,6 @@ function doubleblink () {
 
 function set_time () {
   log "Waiting for time to be set by ntpd..."
-  for i in $(seq 1 10)
-  do
-    if ntp-wait --tries=1 --sleep=1
-    then
-      log "Time now set"
-      return
-    fi
-    sleep 2
-  done
-  log "Time still not set, attempting to force it"
   if ! systemctl stop ntp
   then
     log "Failed to stop ntp daemon"
@@ -409,6 +399,8 @@ function set_time () {
   if ! systemctl start ntp
   then
     log "Failed to start ntp daemon"
+  else
+    log "Time set ..."
   fi
 }
 


### PR DESCRIPTION
In the teslausb application the RPi can only check or set time when it is on the configured or "home" network. When first booted, the RPi time is set to a default time rather than then current time. As a result checking if time is set always return a false result and just slows down the archiveloop process.

Deleted check time and added logging to confirm that time is set.