### PR TITLE
Forced is_sentry_mode_enabled to lowercase

### DIFF
--- a/run/archiveloop
+++ b/run/archiveloop
@@ -287,7 +287,7 @@ function archive_teslacam_clips () {
         declare is_sentry_mode_enabled
         if [ -x /root/bin/tesla_api.py ]
         then
-            is_sentry_mode_enabled=$(/root/bin/tesla_api.py is_sentry_mode_enabled)
+            is_sentry_mode_enabled=$(/root/bin/tesla_api.py is_sentry_mode_enabled | tr '[:upper:]' '[:lower:]')
             if [ "false" = "${is_sentry_mode_enabled}" ]
             then
                 log "Temporarily enabling Sentry Mode to power the RPi while archive job completes..."


### PR DESCRIPTION
`tesla_api.py is_sentry_mode_enabled` returns `True/False` but `archiveloop` is only checking for the lowercase `false`.  Made a change to force the output of `tesla_api.py is_sentry_mode_enabled` to lowercase to ensure proper evaluation later.