### PR TITLE
Fix Bug that will not re-mount cam file

### DIFF
--- a/run/archiveloop
+++ b/run/archiveloop
@@ -298,11 +298,14 @@ function archive_teslacam_clips () {
         /root/bin/archive-clips.sh
 
         # If Sentry Mode was previously disabled, restore it to that state
-        if [ "false" = "${is_sentry_mode_enabled}" ]
+        if [ -x /root/bin/tesla_api.py ]
         then
-            log "Restoring Sentry Mode to its previous state (disabled)..."
-            /root/bin/tesla_api.py disable_sentry_mode &>> ${LOG_FILE}
-        fi
+	    if [ "false" = "${is_sentry_mode_enabled}" ]
+	    then
+	        log "Restoring Sentry Mode to its previous state (disabled)..."
+   	         /root/bin/tesla_api.py disable_sentry_mode &>> ${LOG_FILE}
+	    fi
+	fi
     fi
 
     unmount_cam_file


### PR DESCRIPTION
The check for teslapi is not done a second time. This will cause it to fail after archiving clips, if you  don't use the api  to keep awake.