### PR TITLE
Changes to support ext-usb for Pi4

### DIFF
--- a/doc/Pi4ExternalDriveSetup.md
+++ b/doc/Pi4ExternalDriveSetup.md
@@ -1,0 +1,23 @@
+# Setting up external USB drive (SSD) with Pi4 
+This guide will walk you through how to use Pi4 and a separate USB drive to to host your CAM and MUSIC files. 
+
+#### Limitations
+- Early release. Still being tested - 9.2019
+- Supports manual setup. Not tested yet with headless setup. 
+- Pi4 does not support booting from USB drive. A SD card is still needed for boot. It can be as small as 4GB and no high endurance required as most data will be written and read from the attached USB. 
+- Will erase entire disk. All data on disk will be lost. 
+- Cannot resize existing partitions. 
+
+## Hardware
+1. Raspberry Pi4 - Any RAM option will work. 
+2. At least 4GB SD card - !! ONLY IF USING AN EXTERNAL DRIVE !! Refer to main page if you are not using external drive. 
+3. USB Drive - SSD preferred due to low power requirements. 
+4. Optional, but highly recommended - Heatsink case as Pi4 can get very hot. 
+5. Optional - X855 mSata board for a more compact setup. 
+
+## teslausb_setup_variables.conf configuration
+To use an external USB drive, you will need to add 
+``` export usb_drive=/dev/sdX ``` to teslausb_setup_variables.conf file. 
+Ensure that you are providing the disk location and not a partition.
+
+The rest of the setup is the same as the installation steps found in the main page. Both /backingfiles and /mutable will be on the external drive and the SD card will be read-only. 

--- a/doc/teslausb_setup_variables.conf.sample
+++ b/doc/teslausb_setup_variables.conf.sample
@@ -17,6 +17,11 @@ export sharename=your_archive_share_name
 export shareuser=username
 export sharepassword=password
 # export cifs_version="3.0"
+
+# Uncomment the follwing line and select drive if you want to use an external drive instead of built-in MicroSD card. 
+# External USB drive is supported only for RPi4. 
+# export usb_drive=/dev/sda
+
 export camsize=100%
 
 # if you set camsize to less than 100%, but don't want music to use

--- a/setup/pi/create-backingfiles-partition.sh
+++ b/setup/pi/create-backingfiles-partition.sh
@@ -16,6 +16,50 @@ then
   apt-get -y --force-yes install xfsprogs
 fi
 
+# Will check for USB Drive before running sd card
+if [ ! -z "$usb_drive" ]
+then
+  setup_progress "usb_drive is set to $usb_drive"
+  # Check if backingfiles and mutable partitions exist
+  if [ /dev/disk/by-label/backingfiles -ef /dev/sda2 -a /dev/disk/by-label/mutable -ef /dev/sda1 ]
+  then
+    setup_progress "Looks like backingfiles and mutable partitions already exist. Exiting without making changes"
+    exit 0
+  else
+    setup_progress "WARNING !!! This will delete EVERYTHING in $usb_drive."
+    wipefs -afq $usb_drive
+    parted $usb_drive --script mktable gpt
+    setup_progress "$usb_drive fully erased. Creating partitions..."
+    parted -a optimal -m /dev/sda mkpart primary ext4 '0%' 2GB
+    parted -a optimal -m /dev/sda mkpart primary ext4 2GB '100%'
+    setup_progress "Backing files and mutable partitions created."
+
+    setup_progress "Formatting new partitions..."
+    # Force creation of filesystems even if previous filesystem appears to exist
+    mkfs.ext4 -F -L mutable /dev/sda1
+    mkfs.xfs -f -m reflink=1 -L backingfiles /dev/sda2
+    
+    BACKINGFILES_MOUNTPOINT="$1"
+    MUTABLE_MOUNTPOINT="$2"
+    if grep -q backingfiles /etc/fstab
+    then
+      setup_progress "backingfiles already defined in /etc/fstab. Not modifying /etc/fstab."
+    else
+      echo "LABEL=backingfiles $BACKINGFILES_MOUNTPOINT xfs auto,rw,noatime 0 2" >> /etc/fstab
+    fi
+    if grep -q 'mutable' /etc/fstab
+    then
+      setup_progress "mutable already defined in /etc/fstab. Not modifying /etc/fstab."
+    else
+      echo "LABEL=mutable $MUTABLE_MOUNTPOINT ext4 auto,rw 0 2" >> /etc/fstab
+    fi
+    setup_progress "Partitions creation complete."
+    exit 0
+  fi
+else
+  echo "usb_drive not set. Proceeding to SD card setup"
+fi
+
 # If partition 3 is the backingfiles partition, type xfs, and
 # partition 4 the mutable partition, type ext4, then return early.
 if [ /dev/disk/by-label/backingfiles -ef /dev/mmcblk0p3 -a \

--- a/setup/pi/setup-teslausb
+++ b/setup/pi/setup-teslausb
@@ -40,6 +40,15 @@ then
       ;;
     esac
   fi
+  # Configuring /boot/cmdline.txt and /etc/modules
+  if ! grep -q dwc2 /etc/modules 
+  then
+    echo -e "dwc2\n" >> /etc/modules
+  fi
+  if ! grep -q 'dtoverlay=dwc2' /boot/config.txt
+  then
+    echo -e "dtoverlay=dwc2\n" >> /boot/config.txt
+  fi
 fi
 
 REPO=${REPO:-marcone}
@@ -52,6 +61,7 @@ SAMBA_ENABLED=${SAMBA_ENABLED:-false}
 SAMBA_GUEST=${SAMBA_GUEST:-false}
 export camsize=${camsize:-90%}
 export musicsize=${musicsize:-100%}
+export usb_drive=${usb_drive:-''}
 
 function setup_progress () {
   local setup_logfile=/boot/teslausb-headless-setup.log


### PR DESCRIPTION
Added Support for external usb drive to be used with Pi4. 

Summary
1. Added documentation
2. Added usb_drive variable
3. Changed files to verify and create partition.
4. Added ability to update /boot/config.txt and /etc/modules in interactive setup mode.