### PR TITLE
More robust Wireless Network config

### DIFF
--- a/pi-gen-sources/00-teslausb-tweaks/files/enable_wifi.sh
+++ b/pi-gen-sources/00-teslausb-tweaks/files/enable_wifi.sh
@@ -34,8 +34,8 @@ function enable_wifi () {
         fi
         setup_progress "Wifi variables specified, and no /boot/WIFI_ENABLED. Building wpa_supplicant.conf."
         cp /boot/wpa_supplicant.conf.sample /boot/wpa_supplicant.conf
-        sed -i'.bak' -e "s/TEMPSSID/${SSID}/g" /boot/wpa_supplicant.conf
-        sed -i'.bak' -e "s/TEMPPASS/${WIFIPASS}/g" /boot/wpa_supplicant.conf
+        sed -i'.bak' -e "sTEMPSSID${SSID}g" /boot/wpa_supplicant.conf
+        sed -i'.bak' -e "sTEMPPASS${WIFIPASS}g" /boot/wpa_supplicant.conf
         cp /boot/wpa_supplicant.conf /etc/wpa_supplicant/wpa_supplicant.conf
         touch /boot/WIFI_ENABLED
         setup_progress "Rebooting..."

--- a/pi-gen-sources/00-teslausb-tweaks/files/rc.local
+++ b/pi-gen-sources/00-teslausb-tweaks/files/rc.local
@@ -50,8 +50,8 @@ function enable_wifi () {
         fi
         setup_progress "Wifi variables specified, and no /boot/WIFI_ENABLED. Building wpa_supplicant.conf."
         cp /boot/wpa_supplicant.conf.sample /boot/wpa_supplicant.conf
-        sed -i'.bak' -e "s/TEMPSSID/${SSID}/g" /boot/wpa_supplicant.conf
-        sed -i'.bak' -e "s/TEMPPASS/${WIFIPASS}/g" /boot/wpa_supplicant.conf
+        sed -i'.bak' -e "sTEMPSSID${SSID}g" /boot/wpa_supplicant.conf
+        sed -i'.bak' -e "sTEMPPASS${WIFIPASS}g" /boot/wpa_supplicant.conf
         cp /boot/wpa_supplicant.conf /etc/wpa_supplicant/wpa_supplicant.conf
 
         # set the host name now if possible, so it's effective immediately after the reboot


### PR DESCRIPTION
Use a non-printable character (^G) as the sed command delimiter.  Should resolve #277 

(The nonprintables are not visible in the diff here, but they are present in the files)