### PR TITLE
Fix losetup error in rerun of setup-teslausb

### DIFF
--- a/setup/pi/create-backingfiles.sh
+++ b/setup/pi/create-backingfiles.sh
@@ -78,6 +78,9 @@ function add_drive () {
   fallocate -l "$size"K "$filename"
   echo "type=c" | sfdisk "$filename" > /dev/null
   local partition_offset=$(first_partition_offset "$filename")
+  for i in /dev/loop0*; do
+    umount $i 2>/dev/null
+  done
   losetup -o $partition_offset loop0 "$filename"
   log_progress "Creating filesystem with label '$label'"
   mkfs.vfat /dev/loop0 -F 32 -n "$label"


### PR DESCRIPTION
When I tried to change the camsize of my teslausb SD card I got this error:

```
usb_drive not set. Proceeding to SD card setup
using existing backingfiles and mutable partitions
TARGET        SOURCE         FSTYPE OPTIONS
/backingfiles /dev/mmcblk0p3 xfs    rw,noatime,attr2,inode64,noquota
Creating backing disk files.
create-backingfiles: starting
create-backingfiles: starting
create-backingfiles: cam: 32G, music: 4G, mountpoint: /backingfiles
create-backingfiles: cam: 32G, music: 4G, mountpoint: /backingfiles
umount: /mnt/cam: not mounted.
umount: /mnt/music: no mount point specified.
create-backingfiles: Allocating 10869484K for /backingfiles/cam_disk.bin...
create-backingfiles: Allocating 10869484K for /backingfiles/cam_disk.bin...
losetup: /backingfiles/cam_disk.bin: failed to set up loop device: Device or resource busy
```

The reason is that `/dev/loop0p1` was already mounted on `/backingfiles/snapshots/snap-000066/mnt`
This patch fixes this issue.