### PR TITLE
Update verify-and-configure-archive.sh

### DIFF
--- a/run/cifs_archive/verify-and-configure-archive.sh
+++ b/run/cifs_archive/verify-and-configure-archive.sh
@@ -85,7 +85,7 @@ function check_archive_mountable () {
 
 function install_required_packages () {
   log_progress "Installing/updating required packages if needed"
-  apt-get -y --force-yes install hping3
+  apt-get -y --allow-unauthenticated install hping3
   log_progress "Done"
 }
 


### PR DESCRIPTION
--force-yes is deprecated on buster, --allow-unauthenticated should be used instead.