### PR TITLE
Update create-backingfiles.sh - Fixes this error message: losetup: /dev/loop0: failed to set up loop device: No such file or directory

### DIFF
--- a/setup/pi/create-backingfiles.sh
+++ b/setup/pi/create-backingfiles.sh
@@ -78,10 +78,14 @@ function add_drive () {
   fallocate -l "$size"K "$filename"
   echo "type=c" | sfdisk "$filename" > /dev/null
   local partition_offset=$(first_partition_offset "$filename")
-  losetup -o $partition_offset loop0 "$filename"
+  local next_dev_loop="$(losetup -f | cut -f3 -d /)"
+  echo "losetup -o $partition_offset $next_dev_loop "$filename""
+  losetup -o $partition_offset $next_dev_loop "$filename"
   log_progress "Creating filesystem with label '$label'"
-  mkfs.vfat /dev/loop0 -F 32 -n "$label"
-  losetup -d /dev/loop0
+  echo "mkfs.vfat $next_dev_loop -F 32 -n "$label""
+  mkfs.vfat /dev/$next_dev_loop -F 32 -n "$label"
+  echo "losetup -d $next_dev_loop"
+  losetup -d /dev/$next_dev_loop
 
   local mountpoint=/mnt/"$name"
 


### PR DESCRIPTION
Fixes this error message: losetup: /dev/loop0: failed to set up loop device: No such file or directory
Also, the whole reason, I was working this issue because I could not mount cam.  "mount /mnt/cam/"

Here is what I did to produce the error:
 ./create-backingfiles.sh 90% 0% /backingfiles
create-backingfiles: starting
create-backingfiles: cam: 90%, music: 0%, mountpoint: /backingfiles
archiveloop: no process found
umount: /mnt/cam: not mounted.
umount: /mnt/music: no mount point specified.
create-backingfiles: Allocating 215409891K for /backingfiles/cam_disk.bin...
losetup -o 1048576 loop0 /backingfiles/cam_disk.bin
losetup: /dev/loop0: failed to set up loop device: No such file or directory