### PR TITLE
rsync via mounted CIFS dir

### DIFF
--- a/run/cifsrsync_archive/archive-clips.sh
+++ b/run/cifsrsync_archive/archive-clips.sh
@@ -1,0 +1,66 @@
+#!/bin/bash -eu
+
+log "Moving clips to archive..."
+
+success=0
+fails=0
+total=0
+
+
+function connectionmonitor {
+  while true
+  do
+    for i in $(seq 1 10)
+    do
+      if timeout 3 /root/bin/archive-is-reachable.sh $ARCHIVE_HOST_NAME
+      then
+        # sleep and then continue outer loop
+        sleep 5
+        continue 2
+      fi
+    done
+    log "connection dead, killing archive-clips"
+    # The archive loop might be stuck on an unresponsive server, so kill it hard.
+    # (should be no worse than losing power in the middle of an operation)
+    kill -9 $1
+    return
+  done
+}
+
+function syncclips(){
+   ROOT="$1"
+   DIR=$(basename $ROOT)
+   mkdir -p $ARCHIVE_MOUNT/$DIR
+
+   for i in $ROOT/*; do
+       rsync -avuz $i $ARCHIVE_MOUNT/$DIR
+	if [ $? -eq 0 ]; then
+		rm -rf $i
+       		log "synced dir $i"
+       		let success=success+1
+	else
+		let fails=fails+1
+		log "rsync failed"
+	fi
+	let totals=totals+1
+   done
+}
+
+connectionmonitor $$ &
+
+# new file name pattern, firmware 2019.*
+syncclips "$CAM_MOUNT/TeslaCam/SavedClips" 
+
+# v10 firmware adds a SentryClips folder
+syncclips "$CAM_MOUNT/TeslaCam/SentryClips" 
+
+kill %1
+
+log "successfully synced $success and removed dirs, failed on $fails, in total $total"
+
+if [ $success -gt 0 ]
+then
+  /root/bin/send-push-message "TeslaUSB:" "successfully synced $success and removed dirs, failed on $fails, in total $total"
+fi
+
+log "Finished rsync over CIFS"

--- a/run/cifsrsync_archive/archive-clips.sh
+++ b/run/cifsrsync_archive/archive-clips.sh
@@ -28,8 +28,8 @@ function connectionmonitor {
 }
 
 function syncclips(){
-   log "function syncclips $1 ---> $(find $ROOT -mindepth 1  -type d)"
    ROOT="$1"
+   log "function syncclips $1 ---> $(find $ROOT -mindepth 1  -type d)"
    DIR=$(basename $ROOT)
    mkdir -p $ARCHIVE_MOUNT/$DIR
 

--- a/run/cifsrsync_archive/archive-clips.sh
+++ b/run/cifsrsync_archive/archive-clips.sh
@@ -28,12 +28,12 @@ function connectionmonitor {
 }
 
 function syncclips(){
-   log "function syncclips $1 ---> $(find $ROOT -mindepth 1  -type d ! -name \".\")"
+   log "function syncclips $1 ---> $(find $ROOT -mindepth 1  -type d)"
    ROOT="$1"
    DIR=$(basename $ROOT)
    mkdir -p $ARCHIVE_MOUNT/$DIR
 
-   for i in $(find $ROOT -mindepth 1 -type d ! -name "."); do
+   for i in $(find $ROOT -mindepth 1 -type d ); do
        log "Syncing $i to $ARCHIVE_MOUNT/$DIR"
        rsync -au $i $ARCHIVE_MOUNT/$DIR > /mutuable/rsync.log 2>&1
 	if [ $? -eq 0 ]; then
@@ -43,7 +43,7 @@ function syncclips(){
 	else
 		let fails=fails+1
 		log "rsync failed"
-                log $(cat /mutuable/rsync.log")
+                log $(cat /mutuable/rsync.log)
 	fi
 	let totals=totals+1
 	rm -f /mutuable/rsync.log

--- a/run/cifsrsync_archive/archive-is-reachable.sh
+++ b/run/cifsrsync_archive/archive-is-reachable.sh
@@ -1,0 +1,5 @@
+#!/bin/bash -eu
+
+ARCHIVE_HOST_NAME="$1"
+
+hping3 -c 1 -S -p 445 "$ARCHIVE_HOST_NAME" > /dev/null 2>&1

--- a/run/cifsrsync_archive/archive-is-reachable.sh
+++ b/run/cifsrsync_archive/archive-is-reachable.sh
@@ -1,4 +1,12 @@
 #!/bin/bash -eu
+if [ -e /tmp/not_reachable ]; then
+   log "overriding - archive not reachable"
+   exit 1
+fi
+if [ -e /tmp/reachable ]; then
+   log "overriding - archive reachable"
+   exit 0
+fi
 
 ARCHIVE_HOST_NAME="$1"
 

--- a/run/cifsrsync_archive/connect-archive.sh
+++ b/run/cifsrsync_archive/connect-archive.sh
@@ -1,0 +1,25 @@
+#!/bin/bash -eu
+
+function ensure_archive_is_mounted () {
+  log "Ensuring cam archive is mounted..."
+  if ensure_mountpoint_is_mounted_with_retry "$ARCHIVE_MOUNT"
+  then
+    log "Ensured cam archive is mounted."
+  else
+    log "Failed to mount cam archive."
+    return 1
+  fi
+  if [ -e "$MUSIC_ARCHIVE_MOUNT" ]
+  then
+    log "Ensuring music archive is mounted..."
+    if ensure_mountpoint_is_mounted_with_retry "$MUSIC_ARCHIVE_MOUNT"
+    then
+      log "Ensured music archive is mounted."
+    else
+      log "Failed to mount music archive."
+      return 1
+    fi
+  fi
+}
+
+ensure_archive_is_mounted

--- a/run/cifsrsync_archive/copy-music.sh
+++ b/run/cifsrsync_archive/copy-music.sh
@@ -1,0 +1,43 @@
+#!/bin/bash -eu
+
+log "Syncing music archive..."
+
+SRC="/mnt/musicarchive"
+DST="/mnt/music"
+
+function connectionmonitor {
+  while true
+  do
+    for i in $(seq 1 10)
+    do
+      if timeout 3 /root/bin/archive-is-reachable.sh $ARCHIVE_HOST_NAME
+      then
+        # sleep and then continue outer loop
+        sleep 5
+        continue 2
+      fi
+    done
+    log "connection dead, killing archive-clips"
+    # The archive loop might be stuck on an unresponsive server, so kill it hard.
+    # (should be no worse than losing power in the middle of an operation)
+    kill -9 $1
+    return
+  done
+}
+
+if ! findmnt --mountpoint $DST
+then
+  log "$DST not mounted, skipping"
+  exit
+fi
+
+connectionmonitor $$ &
+
+rsync -avuz --delete $SRC $DST
+
+
+kill %1
+
+log "sync of music archive finished"
+
+/root/bin/send-push-message "TeslaUSB:" "sync of music archive finished - directories are in sync"

--- a/run/cifsrsync_archive/disconnect-archive.sh
+++ b/run/cifsrsync_archive/disconnect-archive.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -eu
+
+# unmount the archive. Without this, the archive mounts can get into a
+# state where the archive is reachable via the network, appears to be
+# mounted, but the mount is inoperable and any attempt to access it
+# results in a "host is down" message.
+
+log "unmounting $ARCHIVE_MOUNT"
+if ! umount -f -l "$ARCHIVE_MOUNT"
+then
+  log "unmount failed"
+fi
+
+if [ -e "$MUSIC_ARCHIVE_MOUNT" ]
+then
+  log "unmounting $MUSIC_ARCHIVE_MOUNT"
+  if ! umount -f -l "$MUSIC_ARCHIVE_MOUNT"
+  then
+    log "unmount failed"
+  fi
+fi

--- a/run/cifsrsync_archive/verify-and-configure-archive.sh
+++ b/run/cifsrsync_archive/verify-and-configure-archive.sh
@@ -1,0 +1,137 @@
+#!/bin/bash -eu
+
+VERS_OPT=
+SEC_OPT=
+
+function log_progress () {
+  if typeset -f setup_progress > /dev/null; then
+    setup_progress "verify-and-configure-archive: $@"
+  fi
+  echo "verify-and-configure-archive: $1"
+}
+
+function check_archive_server_reachable () {
+  log_progress "Verifying that the archive server $archiveserver is reachable..."
+  local serverunreachable=false
+  hping3 -c 1 -S -p 445 "$archiveserver" 1>/dev/null 2>&1 || serverunreachable=true
+
+  if [ "$serverunreachable" = true ]
+  then
+    log_progress "STOP: The archive server $archiveserver is unreachable. Try specifying its IP address instead."
+    exit 1
+  fi
+
+  log_progress "The archive server is reachable."
+}
+
+function check_archive_mountable () {
+  local test_mount_location="/tmp/archivetestmount"
+
+  log_progress "Verifying that the archive share is mountable..."
+
+  if [ ! -e "$test_mount_location" ]
+  then
+    mkdir "$test_mount_location"
+  fi
+
+  local tmp_credentials_file_path="/tmp/teslaCamArchiveCredentials"
+  /root/bin/write-archive-configs-to.sh "$tmp_credentials_file_path"
+
+  local mounted=false
+  local try_versions="${cifs_version:-@@ default 3.0 2.1 2.0 1.0}"
+  local try_secs="${cifs_sec:-@@ ntlmssp ntlmv2 ntlm}"
+
+  echo "Trying all combinations of vers=($try_versions) and sec=($try_secs)"
+  for vers in $try_versions
+  do
+    for sec in $try_secs
+    do
+      versopt=""
+      secopt=""
+      if [ "$vers" != "@@" ]
+      then
+        versopt="vers=$vers"
+      fi
+      if [ "$sec" != "@@" ]
+      then
+        secopt="sec=$sec"
+      fi
+      local commandline="mount -t cifs '//$1/$2' '$test_mount_location' -o 'credentials=${tmp_credentials_file_path},iocharset=utf8,file_mode=0777,dir_mode=0777,$versopt,$secopt'"
+      log_progress "Trying mount command-line:"
+      log_progress "$commandline"
+      if eval $commandline
+      then
+        mounted=true
+        break 2
+      fi
+    done
+  done
+  if [ "$mounted" = false ]
+  then
+    log_progress "STOP: no working combination of vers and sec mount options worked"
+    exit 1
+  else
+    log_progress "The archive share is mountable using: $commandline"
+    # the music archive must be mountable with the same mount options
+    # so fix the options now
+    export cifs_version=$vers
+    export cifs_sec=$sec
+    VERS_OPT=$versopt
+    SEC_OPT=$secopt
+  fi
+
+  umount "$test_mount_location"
+}
+
+function install_required_packages () {
+  log_progress "Installing/updating required packages if needed"
+  apt-get -y --force-yes install hping3
+  log_progress "Done"
+}
+
+install_required_packages
+
+check_archive_server_reachable
+check_archive_mountable "$archiveserver" "$sharename"
+if [ ! -z ${musicsharename:+x} ]
+then
+  check_archive_mountable "$archiveserver" "$musicsharename"
+fi
+
+function configure_archive () {
+  log_progress "Configuring the archive..."
+
+  local archive_path="/mnt/archive"
+  local music_archive_path="/mnt/musicarchive"
+
+  if [ ! -e "$archive_path" ]
+  then
+    mkdir "$archive_path"
+  fi
+
+  local credentials_file_path="/root/.teslaCamArchiveCredentials"
+  /root/bin/write-archive-configs-to.sh "$credentials_file_path"
+
+  if ! grep -w -q "$archive_path" /etc/fstab
+  then
+    local sharenameforstab=$(echo $sharename | sed 's/ /\\040/g')
+    echo "//$archiveserver/$sharenameforstab $archive_path cifs credentials=${credentials_file_path},iocharset=utf8,file_mode=0777,dir_mode=0777,$VERS_OPT,$SEC_OPT 0" >> /etc/fstab
+  fi
+
+  if [ ! -z ${musicsharename:+x} ]
+  then
+    if [ ! -e "$music_archive_path" ]
+    then
+      mkdir "$music_archive_path"
+    fi
+    if ! grep -w -q "$music_archive_path" /etc/fstab
+    then
+      local musicsharenameforstab=$(echo $musicsharename | sed 's/ /\\040/g')
+      echo "//$archiveserver/$musicsharenameforstab $music_archive_path cifs credentials=${credentials_file_path},iocharset=utf8,file_mode=0777,dir_mode=0777,$VERS_OPT,$SEC_OPT 0" >> /etc/fstab
+    fi
+  fi
+
+  log_progress "Configured the archive."
+}
+
+configure_archive

--- a/run/cifsrsync_archive/write-archive-configs-to.sh
+++ b/run/cifsrsync_archive/write-archive-configs-to.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -eu
+
+FILE_PATH="$1"
+
+echo "username=$shareuser" > "$FILE_PATH"
+echo "password=$sharepassword" >> "$FILE_PATH"

--- a/setup/pi/configure.sh
+++ b/setup/pi/configure.sh
@@ -107,8 +107,7 @@ function check_archive_configs () {
             check_variable "RCLONE_PATH"
             export archiveserver="8.8.8.8" # since it's a cloud hosted drive we'll just set this to google dns
             ;;
-        cifs)
-	cifsrsync)
+        cifs|cifsrsync)
             check_variable "sharename"
             check_variable "shareuser"
             check_variable "sharepassword"

--- a/setup/pi/configure.sh
+++ b/setup/pi/configure.sh
@@ -108,6 +108,7 @@ function check_archive_configs () {
             export archiveserver="8.8.8.8" # since it's a cloud hosted drive we'll just set this to google dns
             ;;
         cifs)
+	cifsrsync)
             check_variable "sharename"
             check_variable "shareuser"
             check_variable "sharepassword"
@@ -137,6 +138,9 @@ function get_archive_module () {
         cifs)
             echo "run/cifs_archive"
             ;;
+	cifsrsync)
+	    echo "run/cifsrsync_archive"
+	    ;;
         none)
             echo "run/none_archive"
             ;;


### PR DESCRIPTION
Hi,

I took the cifs-scripts as a basis and just changed the file copy part. It uses `rsync` now to copy files. In theory this should speed up things a bit. 
Directories will be deleted when rsync finished.
the archive-system is called `cifsrsync`, the rest of the settings remains same compared to `cifs`.

it worked here in a test environment, have to test it in the wild though. 