### PR TITLE
using rsync in CIFS archive system

### DIFF
--- a/run/cifs_archive/archive-clips.sh
+++ b/run/cifs_archive/archive-clips.sh
@@ -41,7 +41,7 @@ function syncclips(){
 		rm -rf $i
        		#log "synced dir $i"
        		let success=success+1
-		let totalFiles=totalFiles+files_moved
+		let totalFiles=totalFiles+num_files_moved
 	else
 		let fails=fails+1
 		log "rsync failed"

--- a/run/cifs_archive/archive-clips.sh
+++ b/run/cifs_archive/archive-clips.sh
@@ -2,72 +2,15 @@
 
 log "syncing clips to archive..."
 
-success=0
-fails=0
-total=0
-totalFiles=0
+num_files_moved=$(rsync -auvh --timeout=60 --remove-source-files --no-perms --stats --log-file=/tmp/archive-rsync-cmd.log $CAM_MOUNT/TeslaCam/SentryClips/* $CAM_MOUNT/TeslaCam/SavedClips/* $ARCHIVE_MOUNT/ | awk '/files transferred/{print $NF}')
 
-
-function connectionmonitor {
-  while true
-  do
-    for i in $(seq 1 10)
-    do
-      if timeout 3 /root/bin/archive-is-reachable.sh $ARCHIVE_HOST_NAME
-      then
-        # sleep and then continue outer loop
-        sleep 5
-        continue 2
-      fi
-    done
-    log "connection dead, killing archive-clips"
-    # The archive loop might be stuck on an unresponsive server, so kill it hard.
-    # (should be no worse than losing power in the middle of an operation)
-    kill -9 $1
-    return
-  done
-}
-
-function syncclips(){
-   ROOT="$1"
-   #log "function syncclips $1 ---> $(find $ROOT -mindepth 1  -type d)"
-   DIR=$(basename $ROOT)
-   mkdir -p $ARCHIVE_MOUNT/$DIR
-
-   for i in $(find $ROOT -mindepth 1 -type d ); do
-       #log "Syncing $i to $ARCHIVE_MOUNT/$DIR"
-       num_files_moved=$(rsync -avuh --timeout=60 --remove-source-files --no-perms --stats --log-file=/mutable/rsync.log $i $ARCHIVE_MOUNT/$DIR | awk '/files transferred/{print $NF}')
-	if [ $? -eq 0 ]; then
-		rm -rf $i
-       		#log "synced dir $i"
-       		let success=success+1
-		let totalFiles=totalFiles+num_files_moved
-	else
-		let fails=fails+1
-		log "rsync failed"
-                log $(cat /mutable/rsync.log)
-	fi
-	let totals=totals+1
-	rm -f /mutable/rsync.log
-   done
-}
-
-connectionmonitor $$ &
-
-# new file name pattern, firmware 2019.*
-#log "syncing saved clips"
-syncclips "$CAM_MOUNT/TeslaCam/SavedClips" 
-#log "now syncing sentry files"
-# v10 firmware adds a SentryClips folder
-syncclips "$CAM_MOUNT/TeslaCam/SentryClips" 
-
-kill %1
-
-log "successfully synced $success and removed dirs, failed on $fails, in total $total, files $totalFiles"
-
-if [ $success -gt 0 ]
+if (( $num_files_moved > 0 ))
 then
-  /root/bin/send-push-message "TeslaUSB:" "successfully synced and removed $success dirs, failed on $fails, in total $total dirs and $totalFiles files were transfered"
+  find $CAM_MOUNT/Teslacam/SavedClips/ $CAM_MOUNT/Teslacam/SentryClips/ -depth -type d -empty -exec rmdir "{}" \;
+  log "Successfully synced files through rsync."
+  /root/bin/send-push-message "TeslaUSB:" "Moved $num_files_moved dashcam files"
+else
+  log "No files archived."
 fi
 
-log "Finished rsync over CIFS"
+


### PR DESCRIPTION
I moved the rsync part out of the branch and replaced the copy-file mechanism.

I did like the "connection-monitoring"-part though, still kept it.
Also, rsync is done on a dir by dir basis. A date directory is deleted when the rsync was successful.
I also took the rsync archive method as inspiration. There were some parameters to rsync I did not know existed 😉 
