### PR TITLE
curl SSL Error Fix

### DIFF
--- a/pi-gen-sources/00-teslausb-tweaks/00-run.sh
+++ b/pi-gen-sources/00-teslausb-tweaks/00-run.sh
@@ -7,7 +7,7 @@ install -m 666 files/wpa_supplicant.conf.sample    "${ROOTFS_DIR}/boot/"
 install -d "${ROOTFS_DIR}/root/bin"
 install -m 755 files/enable_wifi.sh "${ROOTFS_DIR}/root/bin"
 
-on chroot << EOF
+on_chroot << EOF
 ln -s /etc/ssl/certs/ca-certificates.crt /usr/local/share/ca-certificates/ca-certificates.crt
 EOF
 

--- a/pi-gen-sources/00-teslausb-tweaks/00-run.sh
+++ b/pi-gen-sources/00-teslausb-tweaks/00-run.sh
@@ -7,6 +7,10 @@ install -m 666 files/wpa_supplicant.conf.sample    "${ROOTFS_DIR}/boot/"
 install -d "${ROOTFS_DIR}/root/bin"
 install -m 755 files/enable_wifi.sh "${ROOTFS_DIR}/root/bin"
 
+on chroot << EOF
+ln -s /etc/ssl/certs/ca-certificates.crt /usr/local/share/ca-certificates/ca-certificates.crt
+EOF
+
 # Below here is the rest of the stage2 (builds the Stretch lite image)
 # run script commented out just to give guidance on things that can be done.
 

--- a/pi-gen-sources/00-teslausb-tweaks/00-run.sh
+++ b/pi-gen-sources/00-teslausb-tweaks/00-run.sh
@@ -6,6 +6,8 @@ install -m 666 files/teslausb_setup_variables.conf.sample    "${ROOTFS_DIR}/boot
 install -m 666 files/wpa_supplicant.conf.sample    "${ROOTFS_DIR}/boot/"
 install -d "${ROOTFS_DIR}/root/bin"
 install -m 755 files/enable_wifi.sh "${ROOTFS_DIR}/root/bin"
+# Fixes for CURL SSL issues
+install -m 644 files/curlssl.sh "${ROOTFS_DIR}/etc/profile.d/"
 
 on_chroot << EOF
 ln -s /etc/ssl/certs/ca-certificates.crt /usr/local/share/ca-certificates/ca-certificates.crt

--- a/pi-gen-sources/00-teslausb-tweaks/00-run.sh
+++ b/pi-gen-sources/00-teslausb-tweaks/00-run.sh
@@ -9,10 +9,6 @@ install -m 755 files/enable_wifi.sh "${ROOTFS_DIR}/root/bin"
 # Fixes for CURL SSL issues
 install -m 644 files/curlssl.sh "${ROOTFS_DIR}/etc/profile.d/"
 
-on_chroot << EOF
-ln -s /etc/ssl/certs/ca-certificates.crt /usr/local/share/ca-certificates/ca-certificates.crt
-EOF
-
 # Below here is the rest of the stage2 (builds the Stretch lite image)
 # run script commented out just to give guidance on things that can be done.
 

--- a/pi-gen-sources/00-teslausb-tweaks/files/curlssl.sh
+++ b/pi-gen-sources/00-teslausb-tweaks/files/curlssl.sh
@@ -1,0 +1,1 @@
+export CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt


### PR DESCRIPTION
On custom builds with teslausb, curl fails because it can't find the default CA for local.  You can specify on the command line, or as an option, or as an environmental variable ([more info here](https://curl.haxx.se/docs/sslcerts.html)).  All of these don't seem ideal for raspbian teslausb though.  Linking the local CA (which is empty) to the trusted CA fixes this issue.

This PR just adds a check and link creation in the stage7 00-run.sh
`ln -s /etc/ssl/certs/ca-certificates.crt /usr/local/share/ca-certificates/ca-certificates.crt`