### PR TITLE
Only add boot options to cmdline.txt once.

### DIFF
--- a/setup/pi/make-root-fs-readonly.sh
+++ b/setup/pi/make-root-fs-readonly.sh
@@ -13,7 +13,14 @@ log_progress "start"
 
 function append_cmdline_txt_param() {
   local toAppend="$1"
-  sed -i "s/\'/ ${toAppend}/g" /boot/cmdline.txt >/dev/null
+  # Don't add the option if it is already added.
+  # If the command line gets to long the pi won't boot.
+  # Look for the option at the end ($) or in the middle
+  # of the command line and surrounded by space (\s).
+  if ! grep -P -q "\s${toAppend}(\$|\s)" /boot/cmdline.txt
+  then
+    sed -i "s/\'/ ${toAppend}/g" /boot/cmdline.txt >/dev/null
+  fi
 }
 
 log_progress "Removing unwanted packages..."

--- a/setup/pi/make-root-fs-readonly.sh
+++ b/setup/pi/make-root-fs-readonly.sh
@@ -14,7 +14,7 @@ log_progress "start"
 function append_cmdline_txt_param() {
   local toAppend="$1"
   # Don't add the option if it is already added.
-  # If the command line gets to long the pi won't boot.
+  # If the command line gets too long the pi won't boot.
   # Look for the option at the end ($) or in the middle
   # of the command line and surrounded by space (\s).
   if ! grep -P -q "\s${toAppend}(\$|\s)" /boot/cmdline.txt


### PR DESCRIPTION
Running the setup script re-runs the make-root-fs-readonly.sh script
which appends the options 'fastboot', 'noswap', and 'ro' to the cmdline.txt
file. Adding those options repeatedly eventually causes the command line
to get long enough that the Pi won't boot.

This change makes a check for the option in the cmdline.txt before adding
the option so that the command line does not grow without bounds.