### PR TITLE
Use nc instead of hping3 for CIFS connectivity checking

### DIFF
--- a/run/cifs_archive/archive-clips.sh
+++ b/run/cifs_archive/archive-clips.sh
@@ -9,9 +9,9 @@ NUM_FILES_DELETED=0
 function connectionmonitor {
   while true
   do
-    for i in $(seq 1 10)
+    for i in $(seq 1 5)
     do
-      if timeout 3 /root/bin/archive-is-reachable.sh $ARCHIVE_HOST_NAME
+      if timeout 6 /root/bin/archive-is-reachable.sh $ARCHIVE_HOST_NAME
       then
         # sleep and then continue outer loop
         sleep 5

--- a/run/cifs_archive/archive-is-reachable.sh
+++ b/run/cifs_archive/archive-is-reachable.sh
@@ -2,4 +2,4 @@
 
 ARCHIVE_HOST_NAME="$1"
 
-hping3 -c 1 -S -p 445 "$ARCHIVE_HOST_NAME" > /dev/null 2>&1
+nc -z -w 5 "$ARCHIVE_HOST_NAME" 445 > /dev/null 2>&1


### PR DESCRIPTION
This pull request uses nc instead to do the connectivity check.

On my network, I found that while archiving, the connectivity check was failing fairly quickly. For some reason the check using hping3 was not working. While the reasons are not particularly important, my current theory is that the hping3 tool doesn't do a complete TCP connect, it just sends a SYN packet and waits for an ACK. These half open connections are just left to time out. It might be that my Synology NAS's firewall is eventually blocking these, or maybe the network itsself (the router mainly) is filtering these. Certainly, using nc has proven to be more reliable.

I have not investigated whether similar changes could be made to the other connectivity checks, or to other places that hping3 is used in a similar manner - CIFS copy was my immediate problem.
I have just completed a transfer of 513 files successfully (mostly sentry files). Previously it not completing the archive loop, it was always being killed with "connection dead, killing archive-clips".

Oh yeah, this is the very first time I have created a pull request - all a bit new to me - hope this helps.