### PR TITLE
RFC: Change the way snapshots are used.

### DIFF
--- a/doc/teslausb_setup_variables.conf.sample
+++ b/doc/teslausb_setup_variables.conf.sample
@@ -18,10 +18,11 @@ export shareuser=username
 export sharepassword=password
 # export cifs_version="3.0"
 
-# Uncomment the follwing line and select drive if you want to use an external drive instead of built-in MicroSD card. 
-# External USB drive is supported only for RPi4. 
+# Uncomment the following line and select drive if you want to use an external drive instead of built-in MicroSD card.
+# External USB drive is supported only for RPi4.
 # export usb_drive=/dev/sda
 
+# See comments below w/ SNAPSHOTS_ENABLED on appropriate values for the camsize when using snapshots.
 export camsize=100%
 
 # if you set camsize to less than 100%, but don't want music to use
@@ -49,7 +50,21 @@ export HEADLESS_SETUP=true
 #export SAMBA_GUEST=true
 
 # uncomment to disable snapshots. This also disables samba and RecentClips-extension
+#
+# Notes of image sizes when using snapshots:
+#  * camsize should be a fairly small explicit value to leave room for the snapshots.
+#  * musicsize also be an explicit size  but should be large enough to hold your music
+#    library (obviously)
+# Using images that fill the entire available space will make snapshots inoperable.
+# Problems have been encountered with "slow USB" from the cars that seem to correlate
+# to backing drives that are near capacity. For that reason the system tries to keep the
+# backing drive at least 10% available at all times.
 #export SNAPSHOTS_ENABLED=false
+
+# Uncomment to archive the RecentClips.
+# Defaults to false.
+# This requires SNAPSHOTS_ENABLED to be true (default).
+#export ARCHIVE_RECENT_CLIPS=true
 
 # uncomment to enable teslausb to act as a wifi access point with the given
 # SSID, so you can access it while on the road.
@@ -101,6 +116,12 @@ export HEADLESS_SETUP=true
 # power the Pi long enough for the archiving process to complete. To enable
 # that, please provide your Tesla account email and password below.
 # TeslaUSB will only send your credentials to the Tesla API itself.
+#
+# NOTE:  if you do this, it's highly recommended that you set up 'PIN to Drive'
+#   as if the Pi or the car is stolen, the thief has access to your Tesla account
+#   and could change the password, add their own devices as a key, steal the car,
+#   etc.  If either is stolen, CHANGE YOUR TESLA PASSWORD IMMEDIATELY.
+#
 # export tesla_email=joeshmo@gmail.com
 # export tesla_password=teslapass
 # Please also provide your vehicle's VIN, so TeslaUSB can keep the correct
@@ -113,7 +134,7 @@ export HEADLESS_SETUP=true
 # been created yet, i.e. during early setup, and requires an extra
 # reboot. Sizes can be specified as for example "500M" or "2G"
 # export INCREASE_ROOT_SIZE=500M
-#
+
 # Uncomment and change if you want setup scripts to be pulled
 # from a different repo than github.com/marcone/teslausb
 # export REPO=marcone

--- a/doc/teslausb_setup_variables.conf.sample
+++ b/doc/teslausb_setup_variables.conf.sample
@@ -65,6 +65,10 @@ export HEADLESS_SETUP=true
 # Defaults to false.
 # This requires SNAPSHOTS_ENABLED to be true (default).
 #export ARCHIVE_RECENT_CLIPS=true
+# If archiving recent clips by default the cam disk and music disk will not be exposed to the car
+# to prevent more cam files getting created while copying the files off RPi. Enable this option to
+# leave the drives exposed to the car.
+#expost ENABLE_CAM_AND_MUSIC_DRIVES_DURING_RECENT_ARCHIVE=true
 
 # uncomment to enable teslausb to act as a wifi access point with the given
 # SSID, so you can access it while on the road.

--- a/pi-gen-sources/00-teslausb-tweaks/files/enable_wifi.sh
+++ b/pi-gen-sources/00-teslausb-tweaks/files/enable_wifi.sh
@@ -19,12 +19,12 @@ function setup_progress () {
     SETUP_LOGFILE=/boot/teslausb-headless-setup.log
     echo "$( date ) : $1" >> "$SETUP_LOGFILE"
   fi
-    echo $1
+    echo "$1"
 }
 
 function enable_wifi () {
   setup_progress "Detecting whether to update wpa_supplicant.conf"
-  if [ ! -z ${SSID+x} ] && [ ! -z ${WIFIPASS+x} ]
+  if [ -n "${SSID:+x}" ] && [ -n "${WIFIPASS:+x}" ]
   then
       if [ ! -e /boot/WIFI_ENABLED ]
       then

--- a/pi-gen-sources/00-teslausb-tweaks/files/rc.local
+++ b/pi-gen-sources/00-teslausb-tweaks/files/rc.local
@@ -22,7 +22,7 @@ SETUP_LOGFILE=/boot/teslausb-headless-setup.log
 
 function setup_progress () {
   echo "$( date ) : $1" >> "$SETUP_LOGFILE" || echo "can't write to $SETUP_LOGFILE"
-  echo $1
+  echo "$1"
 }
 
 function get_script () {
@@ -40,7 +40,7 @@ function get_script () {
 
 function enable_wifi () {
   setup_progress "Detecting whether to update wpa_supplicant.conf"
-  if [[ ! -z $SSID ]] && [[ ! -z $WIFIPASS ]]
+  if [[ -n "$SSID" ]] && [[ -n "$WIFIPASS" ]]
   then
       if [ ! -e /boot/WIFI_ENABLED ]
       then
@@ -55,8 +55,9 @@ function enable_wifi () {
         cp /boot/wpa_supplicant.conf /etc/wpa_supplicant/wpa_supplicant.conf
 
         # set the host name now if possible, so it's effective immediately after the reboot
-        local old_host_name=$(cat /etc/hostname)
-        if [[ ! -z "$TESLAUSB_HOSTNAME" ]] && [[ "$TESLAUSB_HOSTNAME" != "$old_host_name" ]]
+        local old_host_name
+        old_host_name=$(cat /etc/hostname)
+        if [[ -n "$TESLAUSB_HOSTNAME" ]] && [[ "$TESLAUSB_HOSTNAME" != "$old_host_name" ]]
         then
           local new_host_name="$TESLAUSB_HOSTNAME"
           sed -i -e "s/$old_host_name/$new_host_name/g" /etc/hosts
@@ -108,7 +109,7 @@ then
 
     # Grab the setup variables. Should still be there since setup isn't finished.
     # This is a double check to cover various scenarios of mixed headless/not headless setup attempts
-    if [ -e "/boot/teslausb_setup_variables.conf" -a ! -e  "/root/teslausb_setup_variables.conf" ]
+    if [ -e "/boot/teslausb_setup_variables.conf" ] && [ ! -e  "/root/teslausb_setup_variables.conf" ]
     then
       mv /boot/teslausb_setup_variables.conf /root/
       dos2unix /root/teslausb_setup_variables.conf

--- a/pi-gen-sources/00-teslausb-tweaks/files/stage_flash
+++ b/pi-gen-sources/00-teslausb-tweaks/files/stage_flash
@@ -24,7 +24,7 @@ function flash () {
   while [ ${COUNTER} -lt ${flash_count} ]
   do
     led_flash
-    let COUNTER=COUNTER+1
+    (( COUNTER+=1 ))
   done
 }
 

--- a/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
+++ b/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
@@ -65,6 +65,10 @@ export HEADLESS_SETUP=true
 # Defaults to false.
 # This requires SNAPSHOTS_ENABLED to be true (default).
 #export ARCHIVE_RECENT_CLIPS=true
+# If archiving recent clips by default the cam disk and music disk will not be exposed to the car
+# to prevent more cam files getting created while copying the files off RPi. Enable this option to
+# leave the drives exposed to the car.
+#expost ENABLE_CAM_AND_MUSIC_DRIVES_DURING_RECENT_ARCHIVE=true
 
 # uncomment to enable teslausb to act as a wifi access point with the given
 # SSID, so you can access it while on the road.

--- a/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
+++ b/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
@@ -17,6 +17,12 @@ export sharename=your_archive_share_name
 export shareuser=username
 export sharepassword=password
 # export cifs_version="3.0"
+
+# Uncomment the following line and select drive if you want to use an external drive instead of built-in MicroSD card.
+# External USB drive is supported only for RPi4.
+# export usb_drive=/dev/sda
+
+# See comments below w/ SNAPSHOTS_ENABLED on appropriate values for the camsize when using snapshots.
 export camsize=100%
 
 # if you set camsize to less than 100%, but don't want music to use
@@ -44,7 +50,21 @@ export HEADLESS_SETUP=true
 #export SAMBA_GUEST=true
 
 # uncomment to disable snapshots. This also disables samba and RecentClips-extension
+#
+# Notes of image sizes when using snapshots:
+#  * camsize should be a fairly small explicit value to leave room for the snapshots.
+#  * musicsize also be an explicit size  but should be large enough to hold your music
+#    library (obviously)
+# Using images that fill the entire available space will make snapshots inoperable.
+# Problems have been encountered with "slow USB" from the cars that seem to correlate
+# to backing drives that are near capacity. For that reason the system tries to keep the
+# backing drive at least 10% available at all times.
 #export SNAPSHOTS_ENABLED=false
+
+# Uncomment to archive the RecentClips.
+# Defaults to false.
+# This requires SNAPSHOTS_ENABLED to be true (default).
+#export ARCHIVE_RECENT_CLIPS=true
 
 # uncomment to enable teslausb to act as a wifi access point with the given
 # SSID, so you can access it while on the road.

--- a/run/archiveloop
+++ b/run/archiveloop
@@ -298,7 +298,11 @@ function archive_teslacam_clips () {
             fi
         fi
 
-        /root/bin/archive-clips.sh
+        /root/bin/archive-clips.sh -m -s "$CAM_MOUNT/TeslaCam" -p SentryClips
+        /root/bin/archive-clips.sh -m -s "$CAM_MOUNT/TeslaCam" -p SavedClips
+
+        # Remove empty directories.
+        find $CAM_MOUNT/TeslaCam/ -mindepth 2 -depth -type d -empty -exec rmdir "{}" \;
 
         # If Sentry Mode was previously disabled, restore it to that state
         if [ -x /root/bin/tesla_api.py ]

--- a/run/archiveloop
+++ b/run/archiveloop
@@ -196,18 +196,6 @@ function ensure_mountpoint_is_mounted_with_retry () {
   retry ensure_mountpoint_is_mounted "$1"
 }
 
-function ensure_cam_file_is_mounted () {
-  log "Ensuring cam file is mounted..."
-  ensure_mountpoint_is_mounted_with_retry "$CAM_MOUNT"
-  log "Ensured cam file is mounted."
-}
-
-function ensure_music_file_is_mounted () {
-  log "Ensuring music backing file is mounted..."
-  ensure_mountpoint_is_mounted_with_retry "$MUSIC_MOUNT"
-  log "Ensured music drive is mounted."
-}
-
 function unmount_mount_point () {
   local mount_point="$1"
   log "Unmounting $mount_point..."
@@ -479,13 +467,22 @@ then
     # Detach from the car so we own the drive.
     disconnect_usb_drives_from_host
 
-    # mount, fsck $CAM_MOUNT
+    # fsck and mount $CAM_MOUNT
+    fix_errors_in_image /backingfiles/cam_disk.bin
     ensure_cam_file_is_mounted
 
     # Copy the files out locally. This will remove the files and because of the
     # snapshot above should be largely just deleting files.
     mv_from_image "$CAM_MOUNT"
-    find $CAM_MOUNT/TeslaCam/ -mindepth 2 -depth -type d -empty -exec rmdir "{}" \;
+
+    # Remove any files recovered as part of the FSCK.
+    find "${CAM_MOUNT}" -name "fsck*.rec" -delete
+
+    # Remove empty directories.
+    find ${CAM_MOUNT}/TeslaCam/ -mindepth 2 -depth -type d -empty -exec rmdir "{}" \;
+
+    log "Camera Drive contents after video file removal:"
+    find "${CAM_MOUNT}" -prinf "%10s - %P\n" |& timestamp '| ' >> "$LOG_FILE" || true
 
     # Trim the camera archive to reduce the number of blocks in the snapshot.
     trim_free_space "$CAM_MOUNT"
@@ -645,10 +642,10 @@ else
     log "Checking saved folder count..."
 
     ensure_cam_file_is_mounted
-  
+
     DIR_COUNT=$(cd "$CAM_MOUNT"/TeslaCam && find . -maxdepth 2 -path './SavedClips/*' -type d -o -path './SentryClips/*' -type d | wc -l)
     FILE_COUNT=$(cd "$CAM_MOUNT"/TeslaCam && find . -maxdepth 3 -path './SavedClips/*' -type f -o -path './SentryClips/*' -type f | wc -l)
-  
+
     log "There are $DIR_COUNT event folder(s) with $FILE_COUNT file(s) to move."
 
     if [ "$DIR_COUNT" -gt 0 ]

--- a/run/archiveloop
+++ b/run/archiveloop
@@ -463,10 +463,42 @@ function mount_all_snapshots {
 
 
 function snapshotloop {
+  local interval=1800
+  local now=0
+  local wakeup=0
+
+  # This captures the number of seconds since epoch in 'now'.
+  printf -v now '%(%s)T' -1
+  wakeup=$((now+interval))
+
   while true
   do
-    sleep 3500
+    printf -v now '%(%s)T' -1
+    if [ $wakeup -gt $now ]
+    then
+      sleep $((wakeup-now))
+    fi
+
+    # Compute the next wakeup.
+    printf -v now '%(%s)T' -1
+    wakeup=$((now+interval))
+
     /root/bin/make_snapshot.sh
+
+    # If we can reach the archive go ahead and move the files from
+    # the local drive to the remote archive.
+    if archive_is_reachable
+    then
+      if /root/bin/connect-archive.sh
+      then
+        # We don't keep the car wake here since we are taking advantage of being
+        # connected to the archive. We only keep the car awake when we are first
+        # in contact.
+        /root/bin/archive-clips.sh -m -s "/backingfiles/TeslaCam/" -p SentryClips
+        /root/bin/archive-clips.sh -m -s "/backingfiles/TeslaCam/" -p SavedClips
+      fi
+      #/root/bin/disconnect-archive.sh
+    fi
   done
 }
 

--- a/run/archiveloop
+++ b/run/archiveloop
@@ -396,7 +396,10 @@ function turn_sentry_mode_on () {
     if [ "false" = "${is_sentry_mode_enabled}" ]
     then
       log "Temporarily enabling Sentry Mode to power the RPi while archive job completes..."
-      /root/bin/tesla_api.py enable_sentry_mode &>> ${LOG_FILE}
+      if ! /root/bin/tesla_api.py enable_sentry_mode &>> ${LOG_FILE}
+      then
+        log "Could not enable Sentry Mode..."
+      fi
     fi
   fi
 }
@@ -406,7 +409,10 @@ function turn_sentry_mode_off () {
 	  if [ "false" = "${is_sentry_mode_enabled}" ]
 	  then
 	    log "Restoring Sentry Mode to its previous state (disabled)..."
-      /root/bin/tesla_api.py disable_sentry_mode &>> ${LOG_FILE}
+      if ! /root/bin/tesla_api.py disable_sentry_mode &>> ${LOG_FILE}
+      then
+        log "Could not disable Sentry Mode..."
+      fi
 	  fi
 	fi
 }

--- a/run/archiveloop
+++ b/run/archiveloop
@@ -99,7 +99,6 @@ function set_time () {
   # shellcheck disable=SC2034
   for i in {1..10}
   do
-    log "ntp-wait try $i of 10"
     if ntp-wait --tries=1 --sleep=1
     then
       log "Time now set"
@@ -303,6 +302,9 @@ function connect_usb_drives_to_host() {
   log "Connecting usb to host..."
   modprobe g_mass_storage
   log "Connected usb to host."
+  # Give the file-storage process a boost in I/O priority.
+  # shellcheck disable=SC2046
+  ionice -c 2 -n 0 -p $( pgrep file-storage ) || true
 }
 function disconnect_usb_drives_from_host () {
   log "Disconnecting usb from host..."
@@ -724,12 +726,15 @@ export -f fix_errors_in_image
 echo "==============================================" >> "$LOG_FILE"
 log "Starting archiveloop..."
 
+# Let make sure the drives are in good shape.
+disconnect_usb_drives_from_host
+fix_errors_in_files
+connect_usb_drives_to_host
+
 # turning off hdmi saves a little bit of power
 /usr/bin/tvservice -o
 
 snapshotloop &
-
-fix_errors_in_files
 
 if archive_is_reachable
 then
@@ -738,7 +743,7 @@ then
   set_time
 
   archive_clips
-
+  truncate_log
   doubleblink
 
   connect_usb_drives_to_host
@@ -746,11 +751,6 @@ then
   wait_for_archive_to_be_unreachable
 else
   slowblink
-
-  # Let make sure the drives are in good shape.
-  disconnect_usb_drives_from_host
-  fix_errors_in_files
-  connect_usb_drives_to_host
 fi
 
 while true

--- a/run/archiveloop
+++ b/run/archiveloop
@@ -6,9 +6,9 @@ export MUSIC_MOUNT=/mnt/music
 export ARCHIVE_MOUNT=/mnt/archive
 export MUSIC_ARCHIVE_MOUNT=/mnt/musicarchive
 
-if [ "$BASH_SOURCE" != "$0" ]
+if [ "${BASH_SOURCE[0]}" != "$0" ]
 then
-  echo "$BASH_SOURCE must be executed, not sourced"
+  echo "{BASH_SOURCE[0]} must be executed, not sourced"
   return 1 # shouldn't use exit when sourced
 fi
 
@@ -55,7 +55,7 @@ function isPi4 {
 }
 function timestamp () {
   local prefix=${1:-}
-  while IFS= read line
+  while IFS= read -r line
   do
     echo "$(date): $prefix$line"
   done
@@ -84,7 +84,8 @@ function retry () {
   return
 }
 function truncate_log () {
-  local log_length=$( wc -l "$LOG_FILE" | cut -d' ' -f 1 )
+  local log_length=0
+  log_length=$( wc -l "$LOG_FILE" | cut -d' ' -f 1 )
   if [ "$log_length" -gt 10000 ]
   then
     log "Truncating log..."
@@ -95,8 +96,10 @@ function truncate_log () {
 }
 function set_time () {
   log "Waiting for time to be set by ntpd..."
+  # shellcheck disable=SC2034
   for i in {1..10}
   do
+    log "ntp-wait try $i of 10"
     if ntp-wait --tries=1 --sleep=1
     then
       log "Time now set"
@@ -225,10 +228,10 @@ function unmount_mount_point () {
 function fix_errors_in_image () {
   local image="$1"
   log "Running fsck on $image..."
-  losetup -f -P $image
-  loopback=$(losetup -j $image | awk '{print $1}' | sed 's/://')
-  /sbin/fsck ${loopback}p1 -- -a |& timestamp '| ' >> "$LOG_FILE" || echo ""
-  losetup -d $loopback
+  losetup -f -P "$image"
+  loopback=$(losetup -j "$image" | awk '{print $1}' | sed 's/://')
+  /sbin/fsck "${loopback}p1" -- -a |& timestamp '| ' >> "$LOG_FILE" || echo ""
+  losetup -d "$loopback"
   log "Finished fsck on $image."
 }
 function fix_errors_in_files () {
@@ -246,10 +249,10 @@ function trim_free_space() {
   then
     loop=$(echo "$found" | awk '{print $2}')
     image=$(losetup -l -n --output=BACK-FILE "$loop")
-    log "Trimming free space in $mount_point, which has $(xfs_bmap $image | wc -l) extents"
+    log "Trimming free space in $mount_point, which has $(xfs_bmap "$image" | wc -l) extents"
     if fstrim "$mount_point" >> "$LOG_FILE" 2>&1
     then
-      log "Trim complete, image now has  $(xfs_bmap $image | wc -l) extents"
+      log "Trim complete, image now has  $(xfs_bmap "$image" | wc -l) extents"
     else
       log "Trimming free space in $mount_point failed."
     fi
@@ -307,7 +310,17 @@ function disconnect_usb_drives_from_host () {
   log "Disconnected usb from host."
 }
 function check_if_usb_drives_is_mounted () {
-    if [ ! -d /sys/devices/platform/soc/??980000.usb/gadget/lun0 ]
+    local found="false"
+    for lun in /sys/devices/platform/soc/??980000.usb/gadget/lun0
+    do
+      if [ -d "$lun" ]
+      then
+        found="true"
+        break
+      fi
+    done
+
+    if [ "$found" = "false" ]
     then
         log "USB Gadget not mounted. Fixing files and remounting..."
         disconnect_usb_drives_from_host
@@ -334,7 +347,7 @@ function archive_is_reachable () {
 }
 function wait_for_archive_to_be_reachable () {
   log "Waiting for archive to be reachable..."
-  while [ true ]
+  while true
   do
     if archive_is_reachable
     then
@@ -352,7 +365,7 @@ function wait_for_archive_to_be_reachable () {
 }
 function wait_for_archive_to_be_unreachable () {
   log "Waiting for archive to be unreachable..."
-  while [ true ]
+  while true
     do
       if ! retry archive_is_reachable
       then
@@ -423,16 +436,16 @@ then
     fi
 
     local destfile="${destdir}/${filename}"
-    if [ ! -e "${destfile}" -o "${file}" -nt "${destfile}" ]
+    if [ ! -e "${destfile}" ] || [ "${file}" -nt "${destfile}" ]
     then
       log "Moving ${group}/.../${filename}"
       # Set the copy to not interfere with the Tesla's I/O
       ionice -t -c 3 rm -f "${destdir}/_${filename}"
-      ionice -t -c 3 cp --preserve=timestamps ${file} "${destdir}/_${filename}"
+      ionice -t -c 3 cp --preserve=timestamps "${file}" "${destdir}/_${filename}"
       mv "${destdir}/_${filename}" "${destfile}"
     else
       log "Removing ${group}/.../${filename} - Already copied."
-      rm ${file}
+      rm "${file}"
     fi
   }
   function mv_from_image {
@@ -497,6 +510,8 @@ then
     local now=0
     local wakeup=0
     local inactivecount=0
+    local prefilecount=0
+    local postfilecount=0
 
     cleanup_snapshots
 
@@ -518,10 +533,10 @@ then
       printf -v now '%(%s)T' -1
       wakeup=$((now+interval))
 
-      local prefilecount=$( find /backingfiles/TeslaCam -type f | wc -l )
+      prefilecount=$( find /backingfiles/TeslaCam -type f | wc -l )
       log "SNAP: Periodic snapshot started."
       /root/bin/make_snapshot.sh
-      local postfilecount=$( find /backingfiles/TeslaCam -type f | wc -l )
+      postfilecount=$( find /backingfiles/TeslaCam -type f | wc -l )
 
       if [ "${prefilecount}" = "${postfilecount}" ]
       then
@@ -615,7 +630,7 @@ else
   
     log "There are $DIR_COUNT event folder(s) with $FILE_COUNT file(s) to move."
 
-    if [ $DIR_COUNT -gt 0 ]
+    if [ "$DIR_COUNT" -gt 0 ]
     then
         log "Starting recording archiving: $DIR_COUNT event folder(s) with $FILE_COUNT file(s)"
 
@@ -714,7 +729,7 @@ log "Starting archiveloop..."
 
 snapshotloop &
 
-mount_and_fix_errors_in_files
+fix_errors_in_files
 
 if archive_is_reachable
 then
@@ -738,7 +753,7 @@ else
   connect_usb_drives_to_host
 fi
 
-while [ true ]
+while true
 do
   slowblink
 
@@ -747,7 +762,7 @@ do
   # Start the archive loop.
   fastblink
   set_time
-  sleep ${ARCHIVE_DELAY:-20}
+  sleep "${ARCHIVE_DELAY:-20}"
 
   archive_clips
   truncate_log

--- a/run/archiveloop
+++ b/run/archiveloop
@@ -1,5 +1,11 @@
 #!/bin/bash -eu
 
+export LOG_FILE=/mutable/archiveloop.log
+export CAM_MOUNT=/mnt/cam
+export MUSIC_MOUNT=/mnt/music
+export ARCHIVE_MOUNT=/mnt/archive
+export MUSIC_ARCHIVE_MOUNT=/mnt/musicarchive
+
 if [ "$BASH_SOURCE" != "$0" ]
 then
   echo "$BASH_SOURCE must be executed, not sourced"
@@ -21,15 +27,6 @@ then
   fi
 fi
 
-# turning off hdmi saves a little bit of power
-/usr/bin/tvservice -o
-
-export LOG_FILE=/mutable/archiveloop.log
-
-export CAM_MOUNT=/mnt/cam
-export MUSIC_MOUNT=/mnt/music
-export ARCHIVE_MOUNT=/mnt/archive
-export MUSIC_ARCHIVE_MOUNT=/mnt/musicarchive
 
 function log () {
   echo -n "$( date ): " >> "$LOG_FILE"
@@ -50,10 +47,12 @@ then
   exit 1
 fi
 
+# Utility Functions.
+#
+# Misc. Functions.
 function isPi4 {
   grep -q "Pi 4" /sys/firmware/devicetree/base/model
 }
-
 function timestamp () {
   local prefix=${1:-}
   while IFS= read line
@@ -61,55 +60,6 @@ function timestamp () {
     echo "$(date): $prefix$line"
   done
 }
-
-function fix_errors_in_image () {
-  local image="$1"
-  log "Running fsck on $image..."
-  losetup -f -P $image
-  loopback=$(losetup -j $image | awk '{print $1}' | sed 's/://')
-  /sbin/fsck ${loopback}p1 -- -a |& timestamp '| ' >> "$LOG_FILE" || echo ""
-  losetup -d $loopback
-  log "Finished fsck on $image."
-}
-
-function archive_is_reachable () {
-  local reachable=true
-
-  /root/bin/archive-is-reachable.sh "$ARCHIVE_HOST_NAME" || reachable=false
-
-  if [ "$reachable" = false ]
-  then
-    false
-    return
-  fi
-  true
-}
-
-function connect_usb_drives_to_host() {
-  log "Connecting usb to host..."
-  modprobe g_mass_storage
-  log "Connected usb to host."
-}
-
-function wait_for_archive_to_be_reachable () {
-  log "Waiting for archive to be reachable..."
-  while [ true ]
-  do
-    if archive_is_reachable
-    then
-      log "Archive is reachable."
-      break
-    fi
-    if [ -e /tmp/archive_is_reachable ]
-    then
-      log "Simulating archive is reachable"
-      rm /tmp/archive_is_reachable
-      break
-    fi
-    sleep 1
-  done
-}
-
 function retry () {
   local attempts=0
   while [ true ]
@@ -133,7 +83,82 @@ function retry () {
   false
   return
 }
+function truncate_log () {
+  local log_length=$( wc -l "$LOG_FILE" | cut -d' ' -f 1 )
+  if [ "$log_length" -gt 10000 ]
+  then
+    log "Truncating log..."
+    local log_file2="${LOG_FILE}.2"
+    tail -n 10000 "$LOG_FILE" > "${LOG_FILE}.2"
+	mv "$log_file2" "$LOG_FILE"
+  fi
+}
+function set_time () {
+  log "Waiting for time to be set by ntpd..."
+  for i in {1..10}
+  do
+    if ntp-wait --tries=1 --sleep=1
+    then
+      log "Time now set"
+      return
+    fi
+    sleep 2
+  done
+  log "Time still not set, attempting to force it"
+  if ! systemctl stop ntp
+  then
+    log "Failed to stop ntp daemon"
+  fi
+  if ! timeout 20 ntpd -q -x -g
+  then
+    log "Failed to set time"
+  fi
+  if ! systemctl start ntp
+  then
+    log "Failed to start ntp daemon"
+  fi
+}
 
+# Blink Functions.
+#
+# Slow, Fast and double blink.
+function slowblink () {
+  echo timer > /sys/class/leds/led0/trigger
+  local ON=on
+  local OFF=off
+  if isPi4
+  then
+    ON=off
+    OFF=on
+  fi
+  echo 900 > /sys/class/leds/led0/delay_$ON
+  echo 100 > /sys/class/leds/led0/delay_$OFF
+}
+function fastblink () {
+  echo timer > /sys/class/leds/led0/trigger
+  local ON=on
+  local OFF=off
+  if isPi4
+  then
+    ON=off
+    OFF=on
+  fi
+  echo 150 > /sys/class/leds/led0/delay_$ON
+  echo 50 > /sys/class/leds/led0/delay_$OFF
+}
+function doubleblink () {
+  echo heartbeat > /sys/class/leds/led0/trigger
+  if isPi4
+  then
+    echo 0 > /sys/class/leds/led0/invert
+  else
+    echo 1 > /sys/class/leds/led0/invert
+  fi
+}
+
+# Generic Mount/Unmount Functions.
+#
+# Mount, Unmount and FSCK functions.
 function mount_mountpoint () {
   local mount_point="$1"
   log "Mounting $mount_point..."
@@ -151,7 +176,6 @@ function mount_mountpoint () {
     return
   fi
 }
-
 function ensure_mountpoint_is_mounted () {
   local mount_point="$1"
   local mount_exists=true
@@ -198,15 +222,134 @@ function unmount_mount_point () {
     fi
   fi
 }
+function fix_errors_in_image () {
+  local image="$1"
+  log "Running fsck on $image..."
+  losetup -f -P $image
+  loopback=$(losetup -j $image | awk '{print $1}' | sed 's/://')
+  /sbin/fsck ${loopback}p1 -- -a |& timestamp '| ' >> "$LOG_FILE" || echo ""
+  losetup -d $loopback
+  log "Finished fsck on $image."
+}
+function fix_errors_in_files () {
+  fix_errors_in_image /backingfiles/cam_disk.bin
+  if [ -e /backingfiles/music_disk.bin ]
+  then
+    fix_errors_in_image /backingfiles/music_disk.bin
+  fi
+}
+function trim_free_space() {
+  local mount_point="$1"
 
+  # Make sure the partition is mounted.
+  if found=$(findmnt -n --mountpoint "$mount_point")
+  then
+    loop=$(echo "$found" | awk '{print $2}')
+    image=$(losetup -l -n --output=BACK-FILE "$loop")
+    log "Trimming free space in $mount_point, which has $(xfs_bmap $image | wc -l) extents"
+    if fstrim "$mount_point" >> "$LOG_FILE" 2>&1
+    then
+      log "Trim complete, image now has  $(xfs_bmap $image | wc -l) extents"
+    else
+      log "Trimming free space in $mount_point failed."
+    fi
+  fi
+}
+
+# Camera Disk Image Mount/Unmount Functions.
+#
+# Mount, Unmount and FSCK functions for the camera image.
+function ensure_cam_file_is_mounted () {
+  log "Ensuring cam file is mounted..."
+  ensure_mountpoint_is_mounted_with_retry "$CAM_MOUNT"
+  log "Ensured cam file is mounted."
+}
 function unmount_cam_file () {
   unmount_mount_point "$CAM_MOUNT"
 }
 
+
+# Music Disk Image Mount/Unmount Functions.
+#
+# Mount, Unmount and FSCK functions for the music image.
+function ensure_music_file_is_mounted () {
+  if [ -e "$MUSIC_MOUNT" ]
+  then
+    log "Ensuring music backing file is mounted..."
+    ensure_mountpoint_is_mounted_with_retry "$MUSIC_MOUNT"
+    log "Ensured music drive is mounted."
+  fi
+}
 function unmount_music_file () {
-  unmount_mount_point "$MUSIC_MOUNT"
+  if [ -e "$MUSIC_MOUNT" ]
+  then
+    unmount_mount_point "$MUSIC_MOUNT"
+  fi
+}
+function fix_errors_in_music_file () {
+  if [ -e "$MUSIC_MOUNT" ]
+  then
+    fix_errors_in_image /backingfiles/music_disk.bin
+  fi
 }
 
+# USB Drive Functions
+#
+# Connect and disconnect the images to the car via the g_mass_storage gadget.
+function connect_usb_drives_to_host() {
+  log "Connecting usb to host..."
+  modprobe g_mass_storage
+  log "Connected usb to host."
+}
+function disconnect_usb_drives_from_host () {
+  log "Disconnecting usb from host..."
+  modprobe -r g_mass_storage
+  log "Disconnected usb from host."
+}
+function check_if_usb_drives_is_mounted () {
+    if [ ! -d /sys/devices/platform/soc/??980000.usb/gadget/lun0 ]
+    then
+        log "USB Gadget not mounted. Fixing files and remounting..."
+        disconnect_usb_drives_from_host
+        fix_errors_in_files
+        connect_usb_drives_to_host
+    fi
+}
+
+
+# Archive Detection Functions
+#
+# Connect and disconnect the images to the car via the g_mass_storage gadget.
+function archive_is_reachable () {
+  local reachable=true
+
+  /root/bin/archive-is-reachable.sh "$ARCHIVE_HOST_NAME" || reachable=false
+
+  if [ "$reachable" = false ]
+  then
+    false
+    return
+  fi
+  true
+}
+function wait_for_archive_to_be_reachable () {
+  log "Waiting for archive to be reachable..."
+  while [ true ]
+  do
+    if archive_is_reachable
+    then
+      log "Archive is reachable."
+      break
+    fi
+    if [ -e /tmp/archive_is_reachable ]
+    then
+      log "Simulating archive is reachable"
+      rm /tmp/archive_is_reachable
+      break
+    fi
+    sleep 1
+  done
+}
 function wait_for_archive_to_be_unreachable () {
   log "Waiting for archive to be unreachable..."
   while [ true ]
@@ -226,51 +369,210 @@ function wait_for_archive_to_be_unreachable () {
   done
 }
 
-function check_if_usb_gadget_is_mounted () {
-    if [ ! -d /sys/devices/platform/soc/??980000.usb/gadget/lun0 ]
+# Sentry Mode Functions.
+#
+# Functions to turn sentry mode on and off.
+# Uses the global 'is_sentry_mode_enabled'
+declare is_sentry_mode_enabled
+function turn_sentry_mode_on () {
+  if [ -x /root/bin/tesla_api.py ]
+  then
+    is_sentry_mode_enabled=$(/root/bin/tesla_api.py is_sentry_mode_enabled | tr '[:upper:]' '[:lower:]')
+    if [ "false" = "${is_sentry_mode_enabled}" ]
     then
-        log "USB Gadget not mounted. Fixing files and remounting..."
-        disconnect_usb_drives_from_host
-        mount_and_fix_errors_in_files
-        connect_usb_drives_to_host
+      log "Temporarily enabling Sentry Mode to power the RPi while archive job completes..."
+      /root/bin/tesla_api.py enable_sentry_mode &>> ${LOG_FILE}
     fi
+  fi
+}
+function turn_sentry_mode_off () {
+  if [ -x /root/bin/tesla_api.py ]
+  then
+	  if [ "false" = "${is_sentry_mode_enabled}" ]
+	  then
+	    log "Restoring Sentry Mode to its previous state (disabled)..."
+      /root/bin/tesla_api.py disable_sentry_mode &>> ${LOG_FILE}
+	  fi
+	fi
 }
 
-function trim_free_space() {
-  local mount_point="$1"
+if [ "${SNAPSHOTS_ENABLED:-true}" = "true" ]
+then
+  function mv_file_to {
+    local group="${1}"
+    local file="${2}"
 
-  # Make sure the partition is mounted.
-  if found=$(findmnt -n --mountpoint "$mount_point")
-  then
-    loop=$(echo $found | awk '{print $2}')
-    image=$(losetup -l -n --output=BACK-FILE $loop)
-    log "Trimming free space in $mount_point, which has $(xfs_bmap $image | wc -l) extents"
-    if fstrim "$mount_point" >> "$LOG_FILE" 2>&1
+    local localdir=/backingfiles/TeslaCam/${group}
+
+    local filedir=${file%/*}
+    local filename=${file##/*/}
+    local filedate=${filename:0:10}
+    local filehour=${filename:11:2}
+    local fileparentdir=${filedir##/*/}
+
+    if [ "${group}" == "RecentClips" ]
     then
-      log "Trim complete, image now has  $(xfs_bmap $image | wc -l) extents"
+      local destdir="${localdir}/${filedate}/${filehour}"
     else
-      log "Trimming free space in $mount_point failed."
+      local destdir="${localdir}/${fileparentdir}"
     fi
-  else
-    log "Could not trim free space in $mount_point. Not Mounted."
-  fi
-}
 
-function mount_and_fix_errors_in_files () {
-  fix_errors_in_image /backingfiles/cam_disk.bin
-  if [ -e /backingfiles/music_disk.bin ]
-  then
-    fix_errors_in_image /backingfiles/music_disk.bin
-  fi
-}
+    if [ ! -d "${destdir}" ]
+    then
+      mkdir -p "${destdir}"
+    fi
 
-function disconnect_usb_drives_from_host () {
-  log "Disconnecting usb from host..."
-  modprobe -r g_mass_storage
-  log "Disconnected usb from host."
-}
+    local destfile="${destdir}/${filename}"
+    if [ ! -e "${destfile}" -o "${file}" -nt "${destfile}" ]
+    then
+      log "Moving ${group}/.../${filename}"
+      # Set the copy to not interfere with the Tesla's I/O
+      ionice -t -c 3 rm -f "${destdir}/_${filename}"
+      ionice -t -c 3 cp --preserve=timestamps ${file} "${destdir}/_${filename}"
+      mv "${destdir}/_${filename}" "${destfile}"
+    else
+      rm ${file}
+    fi
+  }
+  function mv_from_image {
+    local mntpoint="$1"
 
-function archive_teslacam_clips () {
+    for group in SentryClips SavedClips RecentClips
+    do
+      if [ -d "${mntpoint}/TeslaCam/${group}" ] ; then
+        log "Moving files from ${mntpoint}/TeslaCam/${group}..."
+        while IFS= read -r -d '' file
+        do
+          mv_file_to "${group}" "${file}"
+        done < <( find "${mntpoint}/TeslaCam/${group}" -type f -print0 )
+      else
+        log "${mntpoint}/TeslaCam/${group} does not exist. Skipping move."
+      fi
+    done
+  }
+  function archive_teslacam_clips () {
+    # Take a snapshot right before we start archiving files.
+    /root/bin/make_snapshot.sh
+
+    # Detach from the car so we own the drive.
+    disconnect_usb_drives_from_host
+
+    # mount, fsck $CAM_MOUNT
+    ensure_cam_file_is_mounted
+
+    # Copy the files out locally. This will remove the files and because of the
+    # snapshot above should be largely just deleting files.
+    mv_from_image "$CAM_MOUNT"
+    find $CAM_MOUNT/TeslaCam/ -mindepth 2 -depth -type d -empty -exec rmdir "{}" \;
+
+    # Trim the camera archive to reduce the number of blocks in the snapshot.
+    trim_free_space "$CAM_MOUNT"
+
+    # We can now give the mount back to the car.
+    unmount_cam_file
+    connect_usb_drives_to_host
+
+    # Now that the car has the drive back we can do the archive.
+    /root/bin/archive-clips.sh -m -s "/backingfiles/TeslaCam" -p SentryClips
+    /root/bin/archive-clips.sh -m -s "/backingfiles/TeslaCam" -p SavedClips
+    if [ "${ARCHIVE_RECENT_CLIPS:-false}" = "true" ]
+    then
+      /root/bin/archive-clips.sh -m -s "/backingfiles/TeslaCam" -p RecentClips
+    fi
+
+    # Remove empty directories.
+    find /backingfiles/TeslaCam -mindepth 2 -depth -type d -empty -exec rmdir "{}" \;
+  }
+  function cleanup_snapshots {
+    for mount in /backingfiles/snapshots/snap-*/mnt
+    do
+      umount ${mount}
+    done
+    rm -rf  /backingfiles/snapshots/snap-*/snap.bin &> /dev/null
+    log "Removed all old snapshots"
+  }
+  function snapshotloop {
+    local interval=1800
+    local now=0
+    local wakeup=0
+
+    cleanup_snapshots
+
+    # This captures the number of seconds since epoch in 'now'.
+    printf -v now '%(%s)T' -1
+    wakeup=$((now+interval))
+
+    while true
+    do
+      printf -v now '%(%s)T' -1
+      if [ $wakeup -gt $now ]
+      then
+        sleep $((wakeup-now))
+      fi
+
+      # Compute the next wakeup.
+      printf -v now '%(%s)T' -1
+      wakeup=$((now+interval))
+
+      /root/bin/make_snapshot.sh
+
+      # If we can reach the archive go ahead and move the files from
+      # the local drive to the remote archive.
+      if archive_is_reachable
+      then
+        if /root/bin/connect-archive.sh
+        then
+          # We don't keep the car awake here since we are taking advantage of being
+          # connected to the archive. We only keep the car awake when we are in the main archive loop.
+          /root/bin/archive-clips.sh -c -s "/backingfiles/TeslaCam/" -p SentryClips
+          /root/bin/archive-clips.sh -c -s "/backingfiles/TeslaCam/" -p SavedClips
+        fi
+        /root/bin/disconnect-archive.sh
+      fi
+    done
+  }
+  function copy_music_files () {
+    log "Starting music sync..."
+
+    # Make sure nothing is mounted on $MUSIC_MOUNT
+    unmount_music_file
+    /root/bin/release_music_snapshot.sh
+
+    # Take a snapshot of the music image to update.
+    /root/bin/make_music_snapshot.sh
+
+    # Update the music.
+    /root/bin/copy-music.sh
+
+    # Trim the empty space from the music archive.
+    trim_free_space "$MUSIC_MOUNT"
+
+    # Unmount the snapshot - Updated copy is /backingfiles/music_disk.bin.snap.
+    /root/bin/release_music_snapshot.sh
+
+    # Now swap the images.
+    disconnect_usb_drives_from_host
+
+    rm -f /backingfiles/music_disk.bin.old
+    if mv /backingfiles/music_disk.bin /backingfiles/music_disk.bin.old
+    then
+      if mv /backingfiles/music_disk.bin.snap /backingfiles/music_disk.bin
+      then
+        log "Updated Music from Archive via snapshot."
+       else
+         mv -f /backingfiles/music_disk.bin.old /backingfiles/music_disk.bin
+         log "Final move failed on  update Music from Archive via snapshot."
+      fi
+    else
+      log "Move failed on  update Music from Archive via snapshot."
+    fi
+
+    connect_usb_drives_to_host
+
+    rm -r /backingfiles/music_disk.bin.old
+  }
+else
+  function archive_teslacam_clips () {
     log "Checking saved folder count..."
 
     ensure_cam_file_is_mounted
@@ -279,24 +581,12 @@ function archive_teslacam_clips () {
     FILE_COUNT=$(cd "$CAM_MOUNT"/TeslaCam && find . -maxdepth 3 -path './SavedClips/*' -type f -o -path './SentryClips/*' -type f | wc -l)
   
     log "There are $DIR_COUNT event folder(s) with $FILE_COUNT file(s) to move."
-  
+
     if [ $DIR_COUNT -gt 0 ]
     then
         log "Starting recording archiving: $DIR_COUNT event folder(s) with $FILE_COUNT file(s)"
 
         /root/bin/send-push-message "TeslaUSB:" "Archiving $DIR_COUNT event folder(s) with $FILE_COUNT file(s) starting at $(date)"
-
-        # Ensure Sentry Mode is enabled before archiving
-        declare is_sentry_mode_enabled
-        if [ -x /root/bin/tesla_api.py ]
-        then
-            is_sentry_mode_enabled=$(/root/bin/tesla_api.py is_sentry_mode_enabled | tr '[:upper:]' '[:lower:]')
-            if [ "false" = "${is_sentry_mode_enabled}" ]
-            then
-                log "Temporarily enabling Sentry Mode to power the RPi while archive job completes..."
-                /root/bin/tesla_api.py enable_sentry_mode &>> ${LOG_FILE}
-            fi
-        fi
 
         /root/bin/archive-clips.sh -m -s "$CAM_MOUNT/TeslaCam" -p SentryClips
         /root/bin/archive-clips.sh -m -s "$CAM_MOUNT/TeslaCam" -p SavedClips
@@ -304,38 +594,44 @@ function archive_teslacam_clips () {
         # Remove empty directories.
         find $CAM_MOUNT/TeslaCam/ -mindepth 2 -depth -type d -empty -exec rmdir "{}" \;
 
-        # If Sentry Mode was previously disabled, restore it to that state
-        if [ -x /root/bin/tesla_api.py ]
-        then
-	    if [ "false" = "${is_sentry_mode_enabled}" ]
-	    then
-	        log "Restoring Sentry Mode to its previous state (disabled)..."
-   	         /root/bin/tesla_api.py disable_sentry_mode &>> ${LOG_FILE}
-	    fi
-	fi
+        # Trim the camera archive to reduce the number of blocks in the snapshot.
+        trim_free_space "$CAM_MOUNT"
     fi
 
     # Trim the camera archive to reduce the number of blocks in the snapshot.
     trim_free_space "$CAM_MOUNT"
 
     unmount_cam_file
-}
+    connect_usb_drives_to_host
+  }
+  function copy_music_files () {
+    log "Starting music sync..."
 
-function copy_music_files () {
-  log "Starting music sync..."
+    disconnect_usb_drives_from_host
 
-  ensure_music_file_is_mounted
+    fix_errors_in_music_file
 
-  /root/bin/copy-music.sh
+    ensure_music_file_is_mounted
 
-  # Trim the empty space from the music archive.
-  trim_free_space "$MUSIC_MOUNT"
+    /root/bin/copy-music.sh
 
-  unmount_music_file
-}
+    # Trim the empty space from the music archive.
+    trim_free_space "$MUSIC_MOUNT"
+
+    unmount_music_file
+    connect_usb_drives_to_host
+  }
+  function snapshotloop {
+    return 0
+  }
+fi
+
 
 function archive_clips () {
   log "Archiving..."
+
+  # Enable sentry mode to keep the power on, if we can.
+  turn_sentry_mode_on
 
   if ! /root/bin/connect-archive.sh
   then
@@ -364,142 +660,9 @@ function archive_clips () {
   fi
 
   /root/bin/disconnect-archive.sh
-}
 
-function truncate_log () {
-  local log_length=$( wc -l "$LOG_FILE" | cut -d' ' -f 1 )
-  if [ "$log_length" -gt 10000 ]
-  then
-    log "Truncating log..."
-    local log_file2="${LOG_FILE}.2"
-    tail -n 10000 "$LOG_FILE" > "${LOG_FILE}.2"
-	mv "$log_file2" "$LOG_FILE"
-  fi
-}
-
-function slowblink () {
-  echo timer > /sys/class/leds/led0/trigger
-  local ON=on
-  local OFF=off
-  if isPi4
-  then
-    ON=off
-    OFF=on
-  fi
-  echo 900 > /sys/class/leds/led0/delay_$ON
-  echo 100 > /sys/class/leds/led0/delay_$OFF
-}
-
-function fastblink () {
-  echo timer > /sys/class/leds/led0/trigger
-  local ON=on
-  local OFF=off
-  if isPi4
-  then
-    ON=off
-    OFF=on
-  fi
-  echo 150 > /sys/class/leds/led0/delay_$ON
-  echo 50 > /sys/class/leds/led0/delay_$OFF
-}
-
-
-function doubleblink () {
-  echo heartbeat > /sys/class/leds/led0/trigger
-  if isPi4
-  then
-    echo 0 > /sys/class/leds/led0/invert
-  else
-    echo 1 > /sys/class/leds/led0/invert
-  fi
-}
-
-function set_time () {
-  log "Waiting for time to be set by ntpd..."
-  for i in {1..10}
-  do
-    if ntp-wait --tries=1 --sleep=1
-    then
-      log "Time now set"
-      return
-    fi
-    sleep 2
-  done
-  log "Time still not set, attempting to force it"
-  if ! systemctl stop ntp
-  then
-    log "Failed to stop ntp daemon"
-  fi
-  if ! timeout 20 ntpd -q -x -g
-  then
-    log "Failed to set time"
-  fi
-  if ! systemctl start ntp
-  then
-    log "Failed to start ntp daemon"
-  fi
-}
-
-function mount_all_snapshots {
-  if ! stat /backingfiles/snapshots/snap-*/snap.bin &> /dev/null
-  then
-    log "no snapshots"
-    return
-  fi
-
-  for img in /backingfiles/snapshots/snap-*/snap.bin
-  do
-    log "mounting snapshot $img"
-    imgdir=$(dirname "$img")
-    if mount | grep "$imgdir/mnt"
-    then
-      echo "$img already mounted"
-      return
-    fi
-    /root/bin/mount_image.sh "$img" "$imgdir/mnt"
-  done
-  log "mounted all snapshots"
-}
-
-
-function snapshotloop {
-  local interval=1800
-  local now=0
-  local wakeup=0
-
-  # This captures the number of seconds since epoch in 'now'.
-  printf -v now '%(%s)T' -1
-  wakeup=$((now+interval))
-
-  while true
-  do
-    printf -v now '%(%s)T' -1
-    if [ $wakeup -gt $now ]
-    then
-      sleep $((wakeup-now))
-    fi
-
-    # Compute the next wakeup.
-    printf -v now '%(%s)T' -1
-    wakeup=$((now+interval))
-
-    /root/bin/make_snapshot.sh
-
-    # If we can reach the archive go ahead and move the files from
-    # the local drive to the remote archive.
-    if archive_is_reachable
-    then
-      if /root/bin/connect-archive.sh
-      then
-        # We don't keep the car wake here since we are taking advantage of being
-        # connected to the archive. We only keep the car awake when we are first
-        # in contact.
-        /root/bin/archive-clips.sh -m -s "/backingfiles/TeslaCam/" -p SentryClips
-        /root/bin/archive-clips.sh -m -s "/backingfiles/TeslaCam/" -p SavedClips
-      fi
-      #/root/bin/disconnect-archive.sh
-    fi
-  done
+  # Disable sentry mode to let the car go to sleep.
+  turn_sentry_mode_off
 }
 
 export ARCHIVE_HOST_NAME
@@ -508,17 +671,15 @@ export -f ensure_mountpoint_is_mounted
 export -f retry
 export -f ensure_mountpoint_is_mounted_with_retry
 export -f log
+export -f fix_errors_in_image
 
 echo "==============================================" >> "$LOG_FILE"
 log "Starting archiveloop..."
 
-mount_all_snapshots
+# turning off hdmi saves a little bit of power
+/usr/bin/tvservice -o
 
-if [ "${SNAPSHOTS_ENABLED:-true}" = "true" ]
-then
-  /root/bin/make_snapshot.sh
-  snapshotloop &
-fi
+snapshotloop &
 
 mount_and_fix_errors_in_files
 
@@ -538,6 +699,9 @@ then
 else
   slowblink
 
+  # Let make sure the drives are in good shape.
+  disconnect_usb_drives_from_host
+  fix_errors_in_files
   connect_usb_drives_to_host
 fi
 
@@ -547,31 +711,16 @@ do
 
   wait_for_archive_to_be_reachable
 
+  # Start the archive loop.
   fastblink
-
   set_time
-
   sleep ${ARCHIVE_DELAY:-20}
 
-  if [ "${SNAPSHOTS_ENABLED:-true}" = "true" ]
-  then
-    # take a snapshot before archive_clips starts deleting files
-    /root/bin/make_snapshot.sh
-  fi
-
-  disconnect_usb_drives_from_host
-
-  mount_and_fix_errors_in_files
-
   archive_clips
-
   truncate_log
-
   doubleblink
-
-  connect_usb_drives_to_host
 
   wait_for_archive_to_be_unreachable
 
-  check_if_usb_gadget_is_mounted
+  check_if_usb_drives_is_mounted
 done

--- a/run/archiveloop
+++ b/run/archiveloop
@@ -62,7 +62,7 @@ function timestamp () {
 }
 function retry () {
   local attempts=0
-  while [ true ]
+  while true
   do
     if eval "$@"
     then
@@ -431,6 +431,7 @@ then
       ionice -t -c 3 cp --preserve=timestamps ${file} "${destdir}/_${filename}"
       mv "${destdir}/_${filename}" "${destfile}"
     else
+      log "Removing ${group}/.../${filename} - Already copied."
       rm ${file}
     fi
   }
@@ -484,17 +485,18 @@ then
     find /backingfiles/TeslaCam -mindepth 2 -depth -type d -empty -exec rmdir "{}" \;
   }
   function cleanup_snapshots {
-    for mount in /backingfiles/snapshots/snap-*/mnt
+    while IFS= read -r -d '' snapdir
     do
-      umount ${mount}
-    done
-    rm -rf  /backingfiles/snapshots/snap-*/snap.bin &> /dev/null
-    log "Removed all old snapshots"
+      log "Removing all old snapshot: ${snapdir}"
+      umount "${snapdir}/mnt" || true
+      rm -rf  "${snapdir}" &> /dev/null
+    done < <( find "/backingfiles/snapshots/" -mindepth 1 -maxdepth 1 -type d -name "snap*" -print0 )
   }
   function snapshotloop {
-    local interval=1800
+    local interval=900
     local now=0
     local wakeup=0
+    local inactivecount=0
 
     cleanup_snapshots
 
@@ -507,27 +509,58 @@ then
       printf -v now '%(%s)T' -1
       if [ $wakeup -gt $now ]
       then
-        sleep $((wakeup-now))
+        local tosleep=$((wakeup-now))
+        log "SNAP: Periodic snapshot sleeping ${tosleep} seconds."
+        sleep ${tosleep}
       fi
 
       # Compute the next wakeup.
       printf -v now '%(%s)T' -1
       wakeup=$((now+interval))
 
+      local prefilecount=$( find /backingfiles/TeslaCam -type f | wc -l )
+      log "SNAP: Periodic snapshot started."
       /root/bin/make_snapshot.sh
+      local postfilecount=$( find /backingfiles/TeslaCam -type f | wc -l )
+
+      if [ "${prefilecount}" = "${postfilecount}" ]
+      then
+        # There were no new files in the snapshot.
+        inactivecount=$((inactivecount+1))
+        if [ $inactivecount -gt 1 ] # About 30 minutes.
+        then
+          # remout the drives to the car to try and fix the situation.
+          log "SNAP: CAM drive inactive $inactivecount times in a row. Reconnecting USB..."
+          disconnect_usb_drives_from_host
+          sleep 5
+          check_if_usb_drives_is_mounted
+        else
+          log "SNAP: CAM drive inactive $inactivecount times in a row."
+        fi
+      else
+        inactivecount=0
+      fi
 
       # If we can reach the archive go ahead and move the files from
       # the local drive to the remote archive.
-      if archive_is_reachable
+      if archive_is_reachable && [ -n "$ARCHIVE_MOUNT" ] && ! findmnt --mountpoint "$ARCHIVE_MOUNT" > /dev/null
       then
+        log "SNAP: Attempting a periodic archive."
         if /root/bin/connect-archive.sh
         then
           # We don't keep the car awake here since we are taking advantage of being
           # connected to the archive. We only keep the car awake when we are in the main archive loop.
           /root/bin/archive-clips.sh -c -s "/backingfiles/TeslaCam/" -p SentryClips
           /root/bin/archive-clips.sh -c -s "/backingfiles/TeslaCam/" -p SavedClips
+          if [ "${ARCHIVE_RECENT_CLIPS:-false}" = "true" ]
+          then
+            /root/bin/archive-clips.sh -c -s "/backingfiles/TeslaCam" -p RecentClips
+          fi
         fi
-        /root/bin/disconnect-archive.sh
+        if ! /root/bin/disconnect-archive.sh
+        then
+          log "SNAP: Disconnect of the archive failed."
+        fi
       fi
     done
   }

--- a/run/archiveloop
+++ b/run/archiveloop
@@ -97,15 +97,11 @@ function truncate_log () {
 function set_time () {
   log "Waiting for time to be set by ntpd..."
   # shellcheck disable=SC2034
-  for i in {1..10}
-  do
-    if ntp-wait --tries=1 --sleep=1
-    then
-      log "Time now set"
-      return
-    fi
-    sleep 2
-  done
+  if timeout 5 ntp-wait --tries=3 --sleep=1
+  then
+    log "Time now set"
+    return
+  fi
   log "Time still not set, attempting to force it"
   if ! systemctl stop ntp
   then

--- a/run/archiveloop
+++ b/run/archiveloop
@@ -458,8 +458,15 @@ then
       log "Moving ${group}/.../${filename}"
       # Set the copy to not interfere with the Tesla's I/O
       ionice -t -c 3 rm -f "${destdir}/_${filename}"
-      ionice -t -c 3 mv --force "${file}" "${destdir}/_${filename}"
-      mv "${destdir}/_${filename}" "${destfile}"
+      # Use dd to do a copy with the direct flag to avoid trashing the file cache.
+      if ionice -t -c 3 dd bs=1M status=none iflag=direct,noatime if="${file}" oflag=direct of="${destdir}/_${filename}" |& timestamp '| ' >> ${LOG_FILE}
+      then
+        touch --reference "${file}" "${destdir}/_${filename}" || true
+        if mv "${destdir}/_${filename}" "${destfile}"
+        then
+          rm -f "${file}"
+        fi
+      fi
     else
       log "Removing ${group}/.../${filename} - Already copied."
       rm "${file}"

--- a/run/archiveloop
+++ b/run/archiveloop
@@ -213,8 +213,8 @@ function fix_errors_in_image () {
   log "Running fsck on $image..."
   losetup -f -P "$image"
   loopback=$(losetup -j "$image" | awk '{print $1}' | sed 's/://')
-  /sbin/fsck "${loopback}p1" -- -a |& timestamp '| ' >> "$LOG_FILE" || echo ""
-  losetup -d "$loopback"
+  /sbin/fsck "${loopback}p1" -- -a |& timestamp '| ' >> "$LOG_FILE" || true
+  losetup -d "$loopback" || true
   log "Finished fsck on $image."
 }
 function fix_errors_in_files () {

--- a/run/archiveloop
+++ b/run/archiveloop
@@ -377,32 +377,49 @@ function wait_for_archive_to_be_unreachable () {
 # Functions to turn sentry mode on and off.
 # Uses the global 'is_sentry_mode_enabled'
 declare is_sentry_mode_enabled
+
 function turn_sentry_mode_on () {
+  shopt -q -o pipefail
+  local resetpipefail=$?
+  set -o pipefail
+
   if [ -x /root/bin/tesla_api.py ]
   then
     is_sentry_mode_enabled=$(/root/bin/tesla_api.py is_sentry_mode_enabled | tr '[:upper:]' '[:lower:]')
     if [ "false" = "${is_sentry_mode_enabled}" ]
     then
       log "Temporarily enabling Sentry Mode to power the RPi while archive job completes..."
-      if ! /root/bin/tesla_api.py enable_sentry_mode &>> ${LOG_FILE}
+      if ! /root/bin/tesla_api.py enable_sentry_mode |& timestamp '| ' >>  ${LOG_FILE}
       then
         log "Could not enable Sentry Mode..."
       fi
     fi
   fi
+  if [ "$resetpipefail" -eq 1 ]
+  then
+    set +o pipefail
+  fi
 }
 function turn_sentry_mode_off () {
+  shopt -q -o pipefail
+  local resetpipefail=$?
+  set -o pipefail
+
   if [ -x /root/bin/tesla_api.py ]
   then
 	  if [ "false" = "${is_sentry_mode_enabled}" ]
 	  then
 	    log "Restoring Sentry Mode to its previous state (disabled)..."
-      if ! /root/bin/tesla_api.py disable_sentry_mode &>> ${LOG_FILE}
+      if ! /root/bin/tesla_api.py disable_sentry_mode |& timestamp '| ' >> ${LOG_FILE}
       then
         log "Could not disable Sentry Mode..."
       fi
 	  fi
 	fi
+  if [ "$resetpipefail" -eq 1 ]
+  then
+    set +o pipefail
+  fi
 }
 
 if [ "${SNAPSHOTS_ENABLED:-true}" = "true" ]

--- a/run/archiveloop
+++ b/run/archiveloop
@@ -90,8 +90,8 @@ function truncate_log () {
   then
     log "Truncating log..."
     local log_file2="${LOG_FILE}.2"
-    tail -n 10000 "$LOG_FILE" > "${LOG_FILE}.2"
-	mv "$log_file2" "$LOG_FILE"
+    tail -n 10000 "$LOG_FILE" > "${log_file2}"
+	  mv "$log_file2" "$LOG_FILE"
   fi
 }
 function set_time () {
@@ -504,6 +504,9 @@ then
 
     # Remove empty directories.
     find /backingfiles/TeslaCam -mindepth 2 -depth -type d -empty -exec rmdir "{}" \;
+
+    # Mark the free space for the /backingfiles.
+    fstrim /backingfiles || true
   }
   function cleanup_snapshots {
     while IFS= read -r -d '' snapdir
@@ -657,6 +660,9 @@ else
     # Trim the camera archive to reduce the number of blocks in the snapshot.
     trim_free_space "$CAM_MOUNT"
 
+    # Mark the free space for the /backingfiles.
+    fstrim /backingfiles || true
+
     unmount_cam_file
     connect_usb_drives_to_host
   }
@@ -728,6 +734,7 @@ export -f retry
 export -f ensure_mountpoint_is_mounted_with_retry
 export -f log
 export -f fix_errors_in_image
+export -f timestamp
 
 echo "==============================================" >> "$LOG_FILE"
 log "Starting archiveloop..."
@@ -739,6 +746,9 @@ connect_usb_drives_to_host
 
 # turning off hdmi saves a little bit of power
 /usr/bin/tvservice -o
+
+# Mark the free space for the /backingfiles.
+fstrim /backingfiles || true
 
 snapshotloop &
 

--- a/run/archiveloop
+++ b/run/archiveloop
@@ -499,7 +499,17 @@ then
     /root/bin/archive-clips.sh -m -s "/backingfiles/TeslaCam" -p SavedClips
     if [ "${ARCHIVE_RECENT_CLIPS:-false}" = "true" ]
     then
+      if [ "${ENABLE_CAM_AND_MUSIC_DRIVES_DURING_RECENT_ARCHIVE:-false}" != "true" ]
+      then
+         disconnect_usb_drives_from_host
+      fi
+
       /root/bin/archive-clips.sh -m -s "/backingfiles/TeslaCam" -p RecentClips
+
+      if [ "${ENABLE_CAM_AND_MUSIC_DRIVES_DURING_RECENT_ARCHIVE:-false}" != "true" ]
+      then
+         connect_usb_drives_to_host
+      fi
     fi
 
     # Remove empty directories.

--- a/run/archiveloop
+++ b/run/archiveloop
@@ -587,6 +587,7 @@ then
       if [ "${prefilecount}" = "${postfilecount}" ]
       then
         # There were no new files in the snapshot.
+
         inactivecount=$((inactivecount+1))
         if [ $inactivecount -gt 1 ] # About 30 minutes.
         then
@@ -618,9 +619,11 @@ then
             /root/bin/archive-clips.sh -c -s "/backingfiles/TeslaCam" -p RecentClips
           fi
         fi
-        if ! /root/bin/disconnect-archive.sh
+        if /root/bin/disconnect-archive.sh
         then
-          log "SNAP: Disconnect of the archive failed."
+          log "SNAP: Periodic Archive Finished. Disconnected archive."
+        else
+          log "SNAP: Periodic Archive Finished. Disconnecting archive failed."
         fi
       fi
     done

--- a/run/archiveloop
+++ b/run/archiveloop
@@ -375,8 +375,12 @@ function wait_for_archive_to_be_unreachable () {
 declare is_sentry_mode_enabled
 
 function turn_sentry_mode_on () {
-  shopt -q -o pipefail
-  local resetpipefail=$?
+  if shopt -q -o pipefail
+  then
+    local resetpipefail=0
+  else
+    local resetpipefail=1
+  fi
   set -o pipefail
 
   if [ -x /root/bin/tesla_api.py ]
@@ -397,8 +401,12 @@ function turn_sentry_mode_on () {
   fi
 }
 function turn_sentry_mode_off () {
-  shopt -q -o pipefail
-  local resetpipefail=$?
+  if shopt -q -o pipefail
+  then
+    local resetpipefail=0
+  else
+    local resetpipefail=1
+  fi
   set -o pipefail
 
   if [ -x /root/bin/tesla_api.py ]
@@ -450,7 +458,7 @@ then
       log "Moving ${group}/.../${filename}"
       # Set the copy to not interfere with the Tesla's I/O
       ionice -t -c 3 rm -f "${destdir}/_${filename}"
-      ionice -t -c 3 cp --preserve=timestamps "${file}" "${destdir}/_${filename}"
+      ionice -t -c 3 mv --force "${file}" "${destdir}/_${filename}"
       mv "${destdir}/_${filename}" "${destfile}"
     else
       log "Removing ${group}/.../${filename} - Already copied."
@@ -495,7 +503,7 @@ then
     find ${CAM_MOUNT}/TeslaCam/ -mindepth 2 -depth -type d -empty -exec rmdir "{}" \;
 
     log "Camera Drive contents after video file removal:"
-    find "${CAM_MOUNT}" -prinf "%10s - %P\n" |& timestamp '| ' >> "$LOG_FILE" || true
+    find "${CAM_MOUNT}" -printf "%10s - %P\n" |& timestamp '| ' >> "$LOG_FILE" || true
 
     # Trim the camera archive to reduce the number of blocks in the snapshot.
     trim_free_space "$CAM_MOUNT"

--- a/run/cifs_archive/archive-clips.sh
+++ b/run/cifs_archive/archive-clips.sh
@@ -1,10 +1,44 @@
 #!/bin/bash -eu
 
-log "Moving clips to archive..."
+# Copies or moves files to the $ARCHIVE_MOUNT via cp/mv.
 
-NUM_FILES_MOVED=0
-NUM_FILES_FAILED=0
-NUM_FILES_DELETED=0
+script=$(basename $0)
+function usage() {
+  echo "usage: $script [-m|-c] -s <source> -p <path>" >&2
+  echo "        -m, -c: Do a [m]ove or [c]opy of the files." >&2
+  echo "                Defaults to copy." >&2
+  echo "   -s <source>: The source path to copy files from." >&2
+  echo "     -p <path>: The subpath for the files to move. " >&2
+  echo "                e.g., 'SentryClips'" >&2
+}
+
+src=""
+extpath=""
+op="Copy"
+op_future="Copying"
+op_past="Copied"
+while getopts 's:p:m' OPTION; do
+  case "$OPTION" in
+    s) src="$OPTARG" ;;
+    p) extpath="$OPTARG" ;;
+    m) op="Move"
+       op_future='Moving'
+       op_past="Moved" ;;
+    c) op="Copy"
+       op_future='Copying'
+       op_past="Copied" ;;
+    *) usage; 
+       exit 1;;
+  esac
+done
+shift "$(($OPTIND -1))"
+
+# Verify the src and extpath are set.
+if [ ! -d "${src}/${extpath}" ]
+then
+  log "Could not find the path to $op clips from: '${src}/${extpath}'"
+  exit 2
+fi
 
 function connectionmonitor {
   while true
@@ -18,7 +52,7 @@ function connectionmonitor {
         continue 2
       fi
     done
-    log "connection dead, killing archive-clips"
+    log "Connection dead, killing ${script}"
     # The archive loop might be stuck on an unresponsive server, so kill it hard.
     # (should be no worse than losing power in the middle of an operation)
     kill -9 $1
@@ -26,71 +60,73 @@ function connectionmonitor {
   done
 }
 
-function moveclips() {
-  ROOT="$1"
-  PATTERN="$2"
-  SUB=$(basename $ROOT)
+function processclips() {
+  local src="$1"
+  local extpath="$2"
+  local base="${src}/${extpath}"
 
-  if [ ! -d "$ROOT" ]
+  NUM_FILES_OPS=0
+  NUM_FILES_FAILED=0
+
+  if [ ! -d "${base}" ]
   then
-    log "$ROOT does not exist, skipping"
+    log "${base} does not exist, skipping"
     return
   fi
 
-  while read file_name
+  while IFS= read -r -d '' file
   do
-    if [ -d "$ROOT/$file_name" ]
+    if [ -f "${base}/${file}" ] 
     then
-      log "Creating output directory '$SUB/$file_name'"
-      if ! mkdir -p "$ARCHIVE_MOUNT/$SUB/$file_name"
-      then
-        log "Failed to create '$SUB/$file_name', check that archive server is writable and has free space"
-        return
-      fi
-    elif [ -f "$ROOT/$file_name" ]
-    then
-      size=$(stat -c%s "$ROOT/$file_name")
-      if [ $size -lt 100000 ]
-      then
-        log "'$SUB/$file_name' is only $size bytes"
-        rm "$ROOT/$file_name"
-        NUM_FILES_DELETED=$((NUM_FILES_DELETED + 1))
-      else
-        log "Moving '$SUB/$file_name'"
-        outdir=$(dirname "$file_name")
-        if mv -f "$ROOT/$file_name" "$ARCHIVE_MOUNT/$SUB/$outdir"
+      relpath=$(dirname "${file}")
+      filename=$(basename "${file}")
+      destdir="$ARCHIVE_MOUNT/${extpath}/${relpath}"
+      destfile="${destdir}/${filename}"
+      if [ ! -e "${destfile}" -o "${base}/${file}" -nt "${destfile}" ]
+      then 
+        log "${op_future} '${extpath}/${file}'"
+        mkdir --parents "${destdir}"
+        if ionice -t -c 3 cp --preserve=timestamps --force "${base}/${file}" "${destdir}/_${filename}"
         then
-          log "Moved '$SUB/$file_name'"
-          NUM_FILES_MOVED=$((NUM_FILES_MOVED + 1))
+          if mv --force "${destdir}/_${filename}" "${destdir}/${filename}"
+          then 
+            if [ "${op}" == "Move" ] 
+            then
+              rm -f "${base}/${file}"
+            fi
+            NUM_FILES_OPS=$((NUM_FILES_OPS + 1))
+          else
+            log "${op_future} '${extpath}/${file}' final move failed."
+            NUM_FILES_FAILED=$((NUM_FILES_FAILED + 1))
+          fi
         else
-          log "Failed to move '$SUB/$file_name'"
+          log "${op_future} '${extpath}/${file}' failed."
           NUM_FILES_FAILED=$((NUM_FILES_FAILED + 1))
         fi
+      else
+        # Already exists on the destination. If doing a move then delete local.
+        if [ "${op}" == "Move" ] 
+        then
+          rm -f "${base}/${file}"
+        fi
       fi
-    else
-      log "$SUB/$file_name not found"
     fi
-  done <<< $(cd "$ROOT"; find $PATTERN)
+  done < <( find ${base} -type f -printf "%P\0" )
+
+  log "${op_past} $NUM_FILES_OPS file(s), ${op_future} $NUM_FILES_FAILED failed."
+  if [ $NUM_FILES_OPS -gt 0 ]
+  then
+    /root/bin/send-push-message "TeslaUSB:" "${op_past} $NUM_FILES_OPS dashcam file(s), $NUM_FILES_FAILED failed."
+  fi
+
+  log "${op_future} ${extpath} clips to archive finished."
 }
 
 connectionmonitor $$ &
 
-# new file name pattern, firmware 2019.*
-moveclips "$CAM_MOUNT/TeslaCam/SavedClips" '*'
-
-# v10 firmware adds a SentryClips folder
-moveclips "$CAM_MOUNT/TeslaCam/SentryClips" '*'
+log "${op_future} clips from ${extpath}..."
+processclips "${src}" "${extpath}"
 
 kill %1
 
-# delete empty directories under SavedClips and SentryClips
-rmdir --ignore-fail-on-non-empty "$CAM_MOUNT/TeslaCam/SavedClips"/* "$CAM_MOUNT/TeslaCam/SentryClips"/* || true
 
-log "Moved $NUM_FILES_MOVED file(s), failed to copy $NUM_FILES_FAILED, deleted $NUM_FILES_DELETED."
-
-if [ $NUM_FILES_MOVED -gt 0 ]
-then
-  /root/bin/send-push-message "TeslaUSB:" "Moved $NUM_FILES_MOVED dashcam file(s), failed to copy $NUM_FILES_FAILED, deleted $NUM_FILES_DELETED."
-fi
-
-log "Finished moving clips to archive."

--- a/run/cifs_archive/archive-clips.sh
+++ b/run/cifs_archive/archive-clips.sh
@@ -92,8 +92,10 @@ function processclips() {
       then 
         log "${op_future} '${extpath}/${file}'"
         mkdir --parents "${destdir}"
-        if ionice -t -c 3 cp --preserve=timestamps --force "${base}/${file}" "${destdir}/_${filename}"
+        # Use dd to do a copy with the direct flag to avoid trashing the file cache.
+        if ionice -t -c 3 dd bs=1M status=none iflag=direct,noatime if="${base}/${file}" oflag=direct of="${destdir}/_${filename}" |& timestamp '| ' >> "${LOG_FILE}"
         then
+          touch --reference "${base}/${file}" "${destdir}/_${filename}" || true
           if mv --force "${destdir}/_${filename}" "${destdir}/${filename}"
           then 
             if [ "${op}" == "Move" ] 

--- a/run/cifs_archive/copy-music.sh
+++ b/run/cifs_archive/copy-music.sh
@@ -14,9 +14,10 @@ DST="/mnt/music"
 function connectionmonitor {
   while true
   do
+    # shellcheck disable=SC2034
     for i in {1..10}
     do
-      if timeout 3 /root/bin/archive-is-reachable.sh $ARCHIVE_HOST_NAME
+      if timeout 3 /root/bin/archive-is-reachable.sh "$ARCHIVE_HOST_NAME"
       then
         # sleep and then continue outer loop
         sleep 5
@@ -26,7 +27,7 @@ function connectionmonitor {
     log "connection dead, killing archive-clips"
     # The archive loop might be stuck on an unresponsive server, so kill it hard.
     # (should be no worse than losing power in the middle of an operation)
-    kill -9 $1
+    kill -9 "$1"
     return
   done
 }
@@ -41,7 +42,7 @@ connectionmonitor $$ &
 
 # Delete files from the local partition(DST) files that do not exist in the 
 # music archive(SRC). This frees space for the new files that may be added.
-while read file_name
+while read -r file_name
 do
   if [ ! -e "$SRC/$file_name" ]
   then
@@ -53,10 +54,10 @@ do
       NUM_FILES_DELETE_ERROR=$((NUM_FILES_DELETE_ERROR + 1))
     fi
   fi
-done <<< "$(cd "$DST"; find * -type f)"
+done <<< "$(cd "$DST"; find ./* -type f)"
 
 # Copy from the music archive(SRC) to the local parition(DST)
-while read file_name
+while read -r file_name
 do
   if [ ! -e "$DST/$file_name" ]
   then
@@ -83,7 +84,7 @@ do
   else
     NUM_FILES_SKIPPED=$((NUM_FILES_SKIPPED + 1))
   fi
-done <<< "$(cd "$SRC"; find * -type f)"
+done <<< "$(cd "$SRC"; find ./* -type f)"
 
 # Stop the connection monitor.
 kill %1

--- a/run/cifs_archive/copy-music.sh
+++ b/run/cifs_archive/copy-music.sh
@@ -59,7 +59,7 @@ done <<< "$(cd "$DST"; find ./* -type f)"
 # Copy from the music archive(SRC) to the local parition(DST)
 while read -r file_name
 do
-  if [ ! -e "$DST/$file_name" ]
+  if [ ! -e "$DST/$file_name" ] || [ "$SRC/$file_name" -nt "$DST/$file_name" ]
   then
     dir=$(dirname "$file_name")
     if ! mkdir -p "$DST/$dir"
@@ -74,8 +74,17 @@ do
       NUM_FILES_ERROR=$((NUM_FILES_ERROR + 1))
       continue
     fi
-    if ! mv "$DST/$dir/__tmp__" "$DST/$file_name"
+    if mv "$DST/$dir/__tmp__" "$DST/$file_name"
     then
+      # Push the modified timestamp forward by a 2 seconds.
+      # since vfat's time resolution is 2 seconds.
+      # This ensures the local copy is "-nt" the remote copy and
+      # does not appear to be "-ot" due to time truncation.
+      src_time=$(stat --format "%Y" "$SRC/$file_name")
+      advanced_time=$(( src_time + 2 ))
+      advanced_time_touch_fmt=$( date --date="@${advanced_time}" --iso-8601=seconds)
+      touch --date="${advanced_time_touch_fmt}" "$DST/$file_name" || true
+    else
       log "Couldn't move to $DST/$file_name"
       NUM_FILES_ERROR=$((NUM_FILES_ERROR + 1))
       continue

--- a/run/cifs_archive/verify-and-configure-archive.sh
+++ b/run/cifs_archive/verify-and-configure-archive.sh
@@ -13,7 +13,7 @@ function log_progress () {
 function check_archive_server_reachable () {
   log_progress "Verifying that the archive server $archiveserver is reachable..."
   local serverunreachable=false
-  hping3 -c 1 -S -p 445 "$archiveserver" 1>/dev/null 2>&1 || serverunreachable=true
+  nc -z -w 5 "$archiveserver" 445 > /dev/null 2>&1 || serverunreachable=true
 
   if [ "$serverunreachable" = true ]
   then
@@ -85,7 +85,7 @@ function check_archive_mountable () {
 
 function install_required_packages () {
   log_progress "Installing/updating required packages if needed"
-  apt-get -y --force-yes install hping3
+  # apt-get -y --force-yes install <packagename>
   log_progress "Done"
 }
 

--- a/run/cifs_archive/verify-and-configure-archive.sh
+++ b/run/cifs_archive/verify-and-configure-archive.sh
@@ -5,12 +5,13 @@ SEC_OPT=
 
 function log_progress () {
   if typeset -f setup_progress > /dev/null; then
-    setup_progress "verify-and-configure-archive: $@"
+    setup_progress "verify-and-configure-archive: $*"
   fi
   echo "verify-and-configure-archive: $1"
 }
 
 function check_archive_server_reachable () {
+  # shellcheck disable=SC2154
   log_progress "Verifying that the archive server $archiveserver is reachable..."
   local serverunreachable=false
   nc -z -w 5 "$archiveserver" 445 > /dev/null 2>&1 || serverunreachable=true
@@ -92,7 +93,9 @@ function install_required_packages () {
 install_required_packages
 
 check_archive_server_reachable
+# shellcheck disable=SC2154
 check_archive_mountable "$archiveserver" "$sharename"
+# shellcheck disable=SC2154
 if [ ! -z ${musicsharename:+x} ]
 then
   check_archive_mountable "$archiveserver" "$musicsharename"
@@ -114,7 +117,8 @@ function configure_archive () {
 
   if ! grep -w -q "$archive_path" /etc/fstab
   then
-    local sharenameforstab=$(echo $sharename | sed 's/ /\\040/g')
+    local sharenameforstab
+    sharenameforstab="${sharename// /\\040}"
     echo "//$archiveserver/$sharenameforstab $archive_path cifs credentials=${credentials_file_path},iocharset=utf8,file_mode=0777,dir_mode=0777,$VERS_OPT,$SEC_OPT 0" >> /etc/fstab
   fi
 
@@ -126,7 +130,8 @@ function configure_archive () {
     fi
     if ! grep -w -q "$music_archive_path" /etc/fstab
     then
-      local musicsharenameforstab=$(echo $musicsharename | sed 's/ /\\040/g')
+      local musicsharenameforstab
+      musicsharenameforstab="${musicsharename// /\\040}"
       echo "//$archiveserver/$musicsharenameforstab $music_archive_path cifs credentials=${credentials_file_path},iocharset=utf8,file_mode=0777,dir_mode=0777,$VERS_OPT,$SEC_OPT 0" >> /etc/fstab
     fi
   fi

--- a/run/cifs_archive/write-archive-configs-to.sh
+++ b/run/cifs_archive/write-archive-configs-to.sh
@@ -2,5 +2,7 @@
 
 FILE_PATH="$1"
 
+# shellcheck disable=SC2154
 echo "username=$shareuser" > "$FILE_PATH"
+# shellcheck disable=SC2154
 echo "password=$sharepassword" >> "$FILE_PATH"

--- a/run/make_music_snapshot.sh
+++ b/run/make_music_snapshot.sh
@@ -1,0 +1,56 @@
+#!/bin/bash -eu
+
+if [ "$BASH_SOURCE" != "$0" ]
+then
+  echo "$BASH_SOURCE must be executed, not sourced"
+  return 1 # shouldn't use exit when sourced
+fi
+
+if [ "${FLOCKED:-}" != "$0" ]
+then
+  mkdir -p $MUSIC_MOUNT
+  if FLOCKED="$0" flock -E 99 $MUSIC_MOUNT "$0" "$@" || case "$?" in
+  99) echo "failed to lock musicsnapshot dir"
+      exit 99
+      ;;
+  *)  exit $?
+      ;;
+  esac
+  then
+    # success
+    exit 0
+  fi
+fi
+
+function snapshot {
+  # Only take a snapshot if the remaining free space is greater than
+  # the size of the cam disk image. Delete older snapshots if necessary
+  # to achieve that.
+  # todo: this could be put in a background task and with a lower free
+  # space requirement, to delete old snapshots just before running out
+  # of space and thus make better use of space
+  local imgsize=$(eval $(stat --format='echo $((%b*%B))' /backingfiles/music_disk.bin))
+  local freespace=$(eval $(stat --file-system --format='echo $((%f*%S))' /backingfiles/music_disk.bin))
+  local fssize=$(eval $(stat --file-system --format='echo $((%b*%S))' /backingfiles/music_disk.bin))
+  if [ $freespace -lt $imgsize ]
+  then
+    log "Insufficient free space ($freespace) to take a music snapshot. Want $imgsize free. Aborting!"
+    return 1
+  fi
+  
+  local name=/backingfiles/music_disk.bin.snap
+  rm -rf "$name"
+  log "Taking music snapshot of music disk: $name"
+  /root/bin/mount_snapshot.sh /backingfiles/music_disk.bin "$name" "$MUSIC_MOUNT"
+  log "Took music snapshot"
+
+  fix_errors_in_image "$name"
+
+  return 0
+}
+
+if ! snapshot
+then
+  log "Failed to take snapshot"
+fi
+

--- a/run/make_music_snapshot.sh
+++ b/run/make_music_snapshot.sh
@@ -49,7 +49,8 @@ function snapshot {
   /root/bin/mount_snapshot.sh /backingfiles/music_disk.bin "$name" "$MUSIC_MOUNT"
   log "Took music snapshot"
 
-  fix_errors_in_image "$name"
+  # Have to mount the file read/write since mount_snapshot mounts read-only.
+  mount "$MUSIC_MOUNT" -o remount,rw
 
   return 0
 }

--- a/run/make_snapshot.sh
+++ b/run/make_snapshot.sh
@@ -22,6 +22,60 @@ then
   fi
 fi
 
+
+function get_current_io_on() {
+  awk '{print $7}' "/sys/block/${1}/stat"
+}
+function wait_for_post_io_surge() {
+
+  # Determined experimentally:
+  # 1 second increase in the written blocks of the device during the camera dump is 40k, 70K, 90K blocks.
+  # Normal background writes are on the order if 1-2K blocks.
+  readonly SURGE_WRITE_SECTORS=10000
+
+  local file="${1}"
+  readonly dev_with_part=$( df "${1}" | awk 'NR == 2 {print $1}' )
+  # Remove the partition from the device name.
+  local dev="${dev_with_part%p[0-9]}"
+  local dev_name="${dev##*/}"
+
+  # Make sure the module is loaded before waiting for a surge.
+  if lsmod | grep -q  g_mass_storage >> /dev/null 2>&1
+  then
+    local last_io
+    local io
+    local delta
+    local spike_start=-1
+    log "Waiting up to 2 minutes for after an I/O surge on ${dev_name} before making the snapshot."
+    io=$( get_current_io_on "${dev_name}" )
+    for i in {1..120}
+    do
+      last_io="${io}"
+
+      sleep 1
+
+      io=$( get_current_io_on "${dev_name}" )
+      delta=$(( io - last_io ))
+
+      if [ "${SURGE_WRITE_SECTORS}" -lt "${delta}"  ]
+      then
+        # We are in an I/O spike. Mark the start.
+        if [ "${spike_start}" -lt "0" ]
+        then
+          spike_start="${i}"
+        fi
+      elif [ "${spike_start}" -gt "0" ] && [ "${delta}" -le "1" ]
+      then
+        # Spike has finushed.
+        local duration=$(( i - spike_start ))
+        log "Waited ${spike_start}s fo a spike in I/O on ${dev_name} that started ${duration}s ago (and just stopped). Taking snapshot."
+        return
+      fi
+    done
+    log "Did not see an I/O surge. Taking snapshot anyway."
+  fi
+}
+
 function copy_file_to {
   local group="${1}"
   local file="${2}"
@@ -65,10 +119,10 @@ function copy_files_for_snapshot {
   do
     if [ -d "${mntpoint}/TeslaCam/${group}" ] ; then
       log "Copying files from ${mntpoint}/TeslaCam/${group}..."
-      while IFS= read -r -d '' file
+      while IFS= read -r file
       do
         copy_file_to "${group}" "${file}"
-      done < <( find "${mntpoint}/TeslaCam/${group}" -type f -print0 )
+      done < <( find "${mntpoint}/TeslaCam/${group}" -type f -print )
     else
       log "${mntpoint}/TeslaCam/${group} does not exist. Skipping copy."
     fi
@@ -128,13 +182,13 @@ function snapshot {
   freespace=$(eval $(stat --file-system --format="echo \$((%f*%S))" /backingfiles/cam_disk.bin))
   # shellcheck disable=SC2046
   fssize=$(eval $(stat --file-system --format="echo \$((%b*%S))" /backingfiles/cam_disk.bin))
-  tenpercentminfree=$(( fssize/ 10 ))
+  tenpercentminfree=$(( fssize / 10 ))
   wanted=$imgsize
 
   if [ "$imgsize" -lt $tenpercentminfree ]
   then
     # Free the larger (10%) of the disk.
-    wanted=tenpercentminfree
+    wanted="$tenpercentminfree"
   fi
   if [ "$freespace" -lt $wanted ]
   then
@@ -155,6 +209,10 @@ function snapshot {
   local snapmnt="$snapdir/mnt"
   local name="$snapdir/snap.bin"
   rm -rf "$snapdir"
+
+  # Wait for just after an I/O surge from the car dumping files.
+  wait_for_post_io_surge /backingfiles/cam_disk.bin
+
   log "Taking snapshot of cam disk: $name"
   /root/bin/mount_snapshot.sh /backingfiles/cam_disk.bin "$name" "$snapmnt"
   log "Took snapshot"

--- a/run/make_snapshot.sh
+++ b/run/make_snapshot.sh
@@ -217,12 +217,15 @@ function snapshot {
   /root/bin/mount_snapshot.sh /backingfiles/cam_disk.bin "$name" "$snapmnt"
   log "Took snapshot"
 
-  fix_errors_in_image "$name"
   copy_files_for_snapshot "$snapmnt"
 
   log "Discarding Snapshot"
   /root/bin/release_snapshot.sh "$snapmnt"
   rm -rf "$snapdir"
+
+  # Make sure the backing device knows about any freed space
+  fstrim /backingfiles || true
+
   return 0
 }
 

--- a/run/mount_image.sh
+++ b/run/mount_image.sh
@@ -3,25 +3,25 @@
 SNAP=$1
 MNT=$2
 
-if [ ! -d $MNT ]
+if [ ! -d "$MNT" ]
 then
-  mkdir -p $MNT
+  mkdir -p "$MNT"
 fi
 
-if mount | grep $MNT
+if mount | grep "$MNT"
 then
   echo "snapshot already mounted"
 fi
 
 # create loopback and scan the partition table, this will create an additional loop
 # device in addition to the main loop device, e.g. /dev/loop0 and /dev/loop0p1
-if [ -z "$(losetup -j $SNAP)" ]
+if [ -z "$(losetup -j "$SNAP")" ]
 then
-  losetup -P -f $SNAP
+  losetup -P -f "$SNAP"
 fi
-PARTLOOP=$(losetup -j $SNAP | awk '{print $1}' | sed 's/:/p1/')
+PARTLOOP=$(losetup -j "$SNAP" | awk '{print $1}' | sed 's/:/p1/')
 #fsck $PARTLOOP -- -a || true
 
-echo mount $PARTLOOP $MNT
-mount -o ro $PARTLOOP $MNT
+echo mount "$PARTLOOP" "$MNT"
+mount -o ro "$PARTLOOP" "$MNT"
 

--- a/run/mount_snapshot.sh
+++ b/run/mount_snapshot.sh
@@ -4,38 +4,38 @@ SRC=$1
 SNAP=$2
 MNT=$3
 
-if mount | grep $MNT
+if mount | grep "$MNT"
 then
   echo "snapshot already mounted"
 fi
 
-if [ ! -d $MNT ]
+if [ ! -d "$MNT" ]
 then
-  mkdir -p $MNT
+  mkdir -p "$MNT"
 fi
 
-SNAPDIR=$(dirname $SNAP)
-if [ ! -d $SNAPDIR ]
+SNAPDIR=$(dirname "$SNAP")
+if [ ! -d "$SNAPDIR" ]
 then
-  mkdir -p $SNAPDIR
+  mkdir -p "$SNAPDIR"
 fi
 
-if [ -e $SNAP ]
+if [ -e "$SNAP" ]
 then
-  umount $MNT || true
-  rm -rf $SNAP
+  umount "$MNT" || true
+  rm -rf "$SNAP"
 fi
 
 # make a copy-on-write snapshot of the current image
-cp --reflink=always $SRC $SNAP
+cp --reflink=always "$SRC" "$SNAP"
 # at this point we have a snapshot of the cam image, which is completely
 # independent of the still in-use image exposed to the car
 
 # create loopback and scan the partition table, this will create an additional loop
 # device in addition to the main loop device, e.g. /dev/loop0 and /dev/loop0p1
-losetup -P -f $SNAP
-PARTLOOP=$(losetup -j $SNAP | awk '{print $1}' | sed 's/:/p1/')
-fsck $PARTLOOP -- -a || true
+losetup -P -f "$SNAP"
+PARTLOOP=$(losetup -j "$SNAP" | awk '{print $1}' | sed 's/:/p1/')
+fsck "$PARTLOOP" -- -a || true
 
-mount -o ro $PARTLOOP $MNT
+mount -o ro "$PARTLOOP" "$MNT"
 

--- a/run/mount_snapshot.sh
+++ b/run/mount_snapshot.sh
@@ -31,6 +31,9 @@ cp --reflink=always "$SRC" "$SNAP"
 # at this point we have a snapshot of the cam image, which is completely
 # independent of the still in-use image exposed to the car
 
+# Fix any errors in the image that we just made a copy of (so could not have been unmounted clean).
+fix_errors_in_image "$SNAP"
+
 # create loopback and scan the partition table, this will create an additional loop
 # device in addition to the main loop device, e.g. /dev/loop0 and /dev/loop0p1
 losetup -P -f "$SNAP"

--- a/run/none_archive/archive-clips.sh
+++ b/run/none_archive/archive-clips.sh
@@ -2,7 +2,7 @@
 
 # Copies or moves files by magic!
 
-script=$(basename $0)
+script=$(basename "$0")
 function usage() {
   echo "usage: $script [-m|-c] -s <source> -p <path>" >&2
   echo "        -m, -c: Do a [m]ove or [c]opy of the files." >&2
@@ -15,26 +15,31 @@ function usage() {
 src=""
 extpath=""
 op="Copy"
-op_future="Copying"
-op_past="Copied"
-cmd=""
-while getopts 's:p:m' OPTION; do
+#op_future="Copying"
+#op_past="Copied"
+#cmd=""
+while getopts 's:p:mc' OPTION; do
   case "$OPTION" in
-    s) src="$OPTARG" ;;
-    p) extpath="$OPTARG" ;;
+    s) src="$OPTARG"
+       ;;
+    p) extpath="$OPTARG"
+       ;;
     m) op="Move"
-       op_future='Moving'
-       op_past="Moved"
-       cmd="--remove-source-files " ;;
+       #op_future='Moving'
+       #op_past="Moved"
+       #cmd="--remove-source-files "
+       ;;
     c) op="Copy"
-       op_future='Copying'
-       op_past="Copied"
-       cmd="" ;;
+       #op_future='Copying'
+       #op_past="Copied"
+       #cmd=""
+       ;;
     *) usage; 
-       exit 1;;
+       exit 1
+       ;;
   esac
 done
-shift "$(($OPTIND -1))"
+shift "$((OPTIND -1))"
 
 # Verify the src and extpath are set.
 if [ ! -d "$src/$extpath" ]

--- a/run/none_archive/archive-clips.sh
+++ b/run/none_archive/archive-clips.sh
@@ -1,3 +1,46 @@
 #!/bin/bash -eu
 
-log "No archive method configured"
+# Copies or moves files by magic!
+
+script=$(basename $0)
+function usage() {
+  echo "usage: $script [-m|-c] -s <source> -p <path>" >&2
+  echo "        -m, -c: Do a [m]ove or [c]opy of the files." >&2
+  echo "                Defaults to copy." >&2
+  echo "   -s <source>: The source path to copy files from." >&2
+  echo "     -p <path>: The subpath for the files to move. " >&2
+  echo "                e.g., 'SentryClips'" >&2
+}
+
+src=""
+extpath=""
+op="Copy"
+op_future="Copying"
+op_past="Copied"
+cmd=""
+while getopts 's:p:m' OPTION; do
+  case "$OPTION" in
+    s) src="$OPTARG" ;;
+    p) extpath="$OPTARG" ;;
+    m) op="Move"
+       op_future='Moving'
+       op_past="Moved"
+       cmd="--remove-source-files " ;;
+    c) op="Copy"
+       op_future='Copying'
+       op_past="Copied"
+       cmd="" ;;
+    *) usage; 
+       exit 1;;
+  esac
+done
+shift "$(($OPTIND -1))"
+
+# Verify the src and extpath are set.
+if [ ! -d "$src/$extpath" ]
+then
+  log "Could not find the path to $op clips from: '$src/$extpath'"
+  exit 2
+fi
+
+log "No archive method configured for ${op}"

--- a/run/rclone_archive/archive-clips.sh
+++ b/run/rclone_archive/archive-clips.sh
@@ -1,25 +1,59 @@
 #!/bin/bash -eu
 
-log "Moving clips to rclone archive..."
+# Copies or moves files to "$drive:$path" via rclone.
+
+script=$(basename $0)
+function usage() {
+  echo "usage: $script [-m|-c] -s <source> -p <path>" >&2
+  echo "        -m, -c: Do a [m]ove or [c]opy of the files." >&2
+  echo "                Defaults to copy." >&2
+  echo "   -s <source>: The source path to copy files from." >&2
+  echo "     -p <path>: The subpath for the files to move. " >&2
+  echo "                e.g., 'SentryClips'" >&2
+}
+
+src=""
+extpath=""
+op="Copy"
+op_future="Copying"
+op_past="Copied"
+cmd="copy --create-empty-src-dirs"
+while getopts 's:p:m' OPTION; do
+  case "$OPTION" in
+    s) src="$OPTARG" ;;
+    p) extpath="$OPTARG" ;;
+    m) op="Move"
+       op_future='Moving'
+       op_past="Moved"
+       cmd="move --create-empty-src-dirs --delete-empty-src-dirs" ;;
+    c) op="Copy"
+       op_future='Copying'
+       op_past="Copied"
+       cmd="copy --create-empty-src-dirs" ;;
+    *) usage; 
+       exit 1;;
+  esac
+done
+shift "$(($OPTIND -1))"
+
+# Verify the src and extpath are set.
+if [ ! -d "$src/$extpath" ]
+then
+  log "Could not find the path to $op clips from: '$src/$extpath'"
+  exit 2
+fi
 
 source /root/.teslaCamRcloneConfig
 
-FILE_COUNT=$(cd "$CAM_MOUNT"/TeslaCam && find . -maxdepth 3 -path './SavedClips/*' -type f -o -path './SentryClips/*' -type f | wc -l)
+file_count=$(find "$src/$extpath" -type f | wc -l)
+lastdir=$(basename "$extpath")
+rclone --config /root/.config/rclone/rclone.conf \
+       ${cmd} \
+       "$src/$extpath" \
+       "$drive:$path"/${lastdir}/ \
+       >> "$LOG_FILE" 2>&1 || echo ""
 
-if [ -d "$CAM_MOUNT"/TeslaCam/SavedClips ]
-then
-  rclone --config /root/.config/rclone/rclone.conf move "$CAM_MOUNT"/TeslaCam/SavedClips "$drive:$path"/SavedClips/ --create-empty-src-dirs --delete-empty-src-dirs >> "$LOG_FILE" 2>&1 || echo ""
-fi
+files_remaining=$(find "$src/$extpath" -type f | wc -l)
 
-if [ -d "$CAM_MOUNT"/TeslaCam/SentryClips ]
-then
-  rclone --config /root/.config/rclone/rclone.conf move "$CAM_MOUNT"/TeslaCam/SentryClips "$drive:$path"/SentryClips/ --create-empty-src-dirs --delete-empty-src-dirs >> "$LOG_FILE" 2>&1 || echo ""
-fi
-
-FILES_REMAINING=$(cd "$CAM_MOUNT"/TeslaCam && find . -maxdepth 3 -path './SavedClips/*' -type f -o -path './SentryClips/*' -type f | wc -l)
-NUM_FILES_MOVED=$((FILE_COUNT-FILES_REMAINING))
-
-log "Moved $NUM_FILES_MOVED file(s)."
-/root/bin/send-push-message "TeslaUSB:" "Moved $NUM_FILES_MOVED dashcam file(s)."
-
-log "Finished moving clips to rclone archive"
+/root/bin/send-push-message "TeslaUSB:" "${op_past} $file_count $extpath files(s), ${files_remaining} remain."
+log "${op_future} $extpath clips to archive via rclone finished."

--- a/run/rclone_archive/archive-clips.sh
+++ b/run/rclone_archive/archive-clips.sh
@@ -2,7 +2,7 @@
 
 # Copies or moves files to "$drive:$path" via rclone.
 
-script=$(basename $0)
+script=$(basename "$0")
 function usage() {
   echo "usage: $script [-m|-c] -s <source> -p <path>" >&2
   echo "        -m, -c: Do a [m]ove or [c]opy of the files." >&2
@@ -18,23 +18,28 @@ op="Copy"
 op_future="Copying"
 op_past="Copied"
 cmd="copy --create-empty-src-dirs"
-while getopts 's:p:m' OPTION; do
+while getopts 's:p:mc' OPTION; do
   case "$OPTION" in
-    s) src="$OPTARG" ;;
-    p) extpath="$OPTARG" ;;
+    s) src="$OPTARG"
+       ;;
+    p) extpath="$OPTARG"
+       ;;
     m) op="Move"
        op_future='Moving'
        op_past="Moved"
-       cmd="move --create-empty-src-dirs --delete-empty-src-dirs" ;;
+       cmd="move --create-empty-src-dirs --delete-empty-src-dirs"
+       ;;
     c) op="Copy"
        op_future='Copying'
        op_past="Copied"
-       cmd="copy --create-empty-src-dirs" ;;
+       cmd="copy --create-empty-src-dirs"
+       ;;
     *) usage; 
-       exit 1;;
+       exit 1
+       ;;
   esac
 done
-shift "$(($OPTIND -1))"
+shift "$((OPTIND -1))"
 
 # Verify the src and extpath are set.
 if [ ! -d "$src/$extpath" ]
@@ -47,10 +52,12 @@ source /root/.teslaCamRcloneConfig
 
 file_count=$(find "$src/$extpath" -type f | wc -l)
 lastdir=$(basename "$extpath")
+# shellcheck disable=SC2154
+# shellcheck disable=SC2086
 rclone --config /root/.config/rclone/rclone.conf \
        ${cmd} \
        "$src/$extpath" \
-       "$drive:$path"/${lastdir}/ \
+       "$drive:$path/${lastdir}/" \
        >> "$LOG_FILE" 2>&1 || echo ""
 
 files_remaining=$(find "$src/$extpath" -type f | wc -l)

--- a/run/rclone_archive/verify-and-configure-archive.sh
+++ b/run/rclone_archive/verify-and-configure-archive.sh
@@ -1,8 +1,9 @@
 #!/bin/bash -eu
 
 function log_progress () {
+  # shellcheck disable=SC2034
   if typeset -f setup_progress > /dev/null; then
-    setup_progress "verify-and-configure-archive: $@"
+    setup_progress "verify-and-configure-archive: $*"
   fi
   echo "verify-and-configure-archive: $1"
 }

--- a/run/release_music_snapshot.sh
+++ b/run/release_music_snapshot.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# for some reason "umount -d" doesn't remove the loop device, so we have to remove it ourselves
+MNT=$(echo "$1" | sed 's/\/$//')
+LOOP=$(mount | grep -w "$MNT" | awk '{print $1}' | sed 's/p1$//')
+SNAP=$(losetup -l --noheadings $LOOP | awk '{print $6}')
+umount $MNT
+losetup -d $LOOP

--- a/run/release_music_snapshot.sh
+++ b/run/release_music_snapshot.sh
@@ -3,6 +3,5 @@
 # for some reason "umount -d" doesn't remove the loop device, so we have to remove it ourselves
 MNT=$(echo "$1" | sed 's/\/$//')
 LOOP=$(mount | grep -w "$MNT" | awk '{print $1}' | sed 's/p1$//')
-SNAP=$(losetup -l --noheadings $LOOP | awk '{print $6}')
-umount $MNT
-losetup -d $LOOP
+umount "$MNT"
+losetup -d "$LOOP"

--- a/run/release_snapshot.sh
+++ b/run/release_snapshot.sh
@@ -3,12 +3,11 @@
 # for some reason "umount -d" doesn't remove the loop device, so we have to remove it ourselves
 MNT=$(echo "$1" | sed 's/\/$//')
 LOOP=$(mount | grep -w "$MNT" | awk '{print $1}' | sed 's/p1$//')
-SNAP=$(losetup -l --noheadings $LOOP | awk '{print $6}')
-umount $MNT
-losetup -d $LOOP
+umount "$MNT"
+losetup -d "$LOOP"
+
 # delete all dead links
-rm -f $(find /backingfiles/TeslaCam/ -xtype l)
+find /backingfiles/TeslaCam/ -xtype l -exec rm -f {} \;
+
 # delete all Sentry, saved and recent folders that are now empty
-rmdir --ignore-fail-on-non-empty /backingfiles/TeslaCam/RecentClips/* || true
-rmdir --ignore-fail-on-non-empty /backingfiles/TeslaCam/SavedClips/* || true
-rmdir --ignore-fail-on-non-empty /backingfiles/TeslaCam/SentryClips/* || true
+find /backingfiles/TeslaCam -mindepth 2 -depth -type d -empty -exec rmdir "{}" \;

--- a/run/rsync_archive/archive-clips.sh
+++ b/run/rsync_archive/archive-clips.sh
@@ -1,16 +1,68 @@
 #!/bin/bash -eu
 
-log "Archiving through rsync..."
+# Copies or moves files to the $user@$server:$path via rsync.
 
-source /root/.teslaCamRsyncConfig
+script=$(basename $0)
+function usage() {
+  echo "usage: $script [-m|-c] -s <source> -p <path>" >&2
+  echo "        -m, -c: Do a [m]ove or [c]opy of the files." >&2
+  echo "                Defaults to copy." >&2
+  echo "   -s <source>: The source path to copy files from." >&2
+  echo "     -p <path>: The subpath for the files to move. " >&2
+  echo "                e.g., 'SentryClips'" >&2
+}
 
-num_files_moved=$(rsync -auvh --timeout=60 --remove-source-files --no-perms --stats --log-file=/tmp/archive-rsync-cmd.log $CAM_MOUNT/TeslaCam/SentryClips/* $CAM_MOUNT/TeslaCam/SavedClips/* $user@$server:$path | awk '/files transferred/{print $NF}')
+src=""
+extpath=""
+op="Copy"
+op_future="Copying"
+op_past="Copied"
+cmd=""
+while getopts 's:p:m' OPTION; do
+  case "$OPTION" in
+    s) src="$OPTARG" ;;
+    p) extpath="$OPTARG" ;;
+    m) op="Move"
+       op_future='Moving'
+       op_past="Moved"
+       cmd="--remove-source-files" ;;
+    c) op="Copy"
+       op_future='Copying'
+       op_past="Copied"
+       cmd="" ;;
+    *) usage; 
+       exit 1;;
+  esac
+done
+shift "$(($OPTIND -1))"
 
-if (( $num_files_moved > 0 ))
+# Verify the src and extpath are set.
+if [ ! -d "${src}/${extpath}" ]
 then
-  find $CAM_MOUNT/Teslacam/SavedClips/ $CAM_MOUNT/Teslacam/SentryClips/ -depth -type d -empty -exec rmdir "{}" \;
-  log "Successfully synced files through rsync."
-  /root/bin/send-push-message "TeslaUSB:" "Moved $num_files_moved dashcam files"
+  log "Could not find the path to $op clips from: '${src}/${extpath}'"
+  exit 2
+fi
+
+log "${op_future} clips from ${src}/${extpath} via rsync..."
+source /root/.teslaCamRsyncConfig
+num_files=$( \
+  rsync ${cmd} --archive \
+        --update \
+        --verbose \
+        --human-readable \
+        --timeout=60 \
+        --no-perms \
+         --stats \
+        --log-file=/tmp/archive-rsync-cmd.log \
+        "${src}/${extpath}"/* \
+        $user@$server:$path \
+      | awk '/files transferred/{print $NF}'
+)
+
+if (( $num_files > 0 ))
+then
+  log "${op_future} ${extpath} clips to archive via rsync finished."
+  /root/bin/send-push-message "TeslaUSB:" "${op_past} ${num_files} dashcam files"
 else
-  log "No files archived."
+  log "No files archived via rsync."
 fi

--- a/run/rsync_archive/archive-clips.sh
+++ b/run/rsync_archive/archive-clips.sh
@@ -2,7 +2,7 @@
 
 # Copies or moves files to the $user@$server:$path via rsync.
 
-script=$(basename $0)
+script=$(basename "$0")
 function usage() {
   echo "usage: $script [-m|-c] -s <source> -p <path>" >&2
   echo "        -m, -c: Do a [m]ove or [c]opy of the files." >&2
@@ -18,23 +18,28 @@ op="Copy"
 op_future="Copying"
 op_past="Copied"
 cmd=""
-while getopts 's:p:m' OPTION; do
+while getopts 's:p:mc' OPTION; do
   case "$OPTION" in
-    s) src="$OPTARG" ;;
-    p) extpath="$OPTARG" ;;
+    s) src="$OPTARG"
+       ;;
+    p) extpath="$OPTARG"
+       ;;
     m) op="Move"
        op_future='Moving'
        op_past="Moved"
-       cmd="--remove-source-files" ;;
+       cmd="--remove-source-files"
+       ;;
     c) op="Copy"
        op_future='Copying'
        op_past="Copied"
-       cmd="" ;;
+       cmd=""
+       ;;
     *) usage; 
-       exit 1;;
+       exit 1
+       ;;
   esac
 done
-shift "$(($OPTIND -1))"
+shift "$((OPTIND -1))"
 
 # Verify the src and extpath are set.
 if [ ! -d "${src}/${extpath}" ]
@@ -45,6 +50,7 @@ fi
 
 log "${op_future} clips from ${src}/${extpath} via rsync..."
 source /root/.teslaCamRsyncConfig
+# shellcheck disable=SC2154
 num_files=$( \
   rsync ${cmd} --archive \
         --update \
@@ -55,11 +61,11 @@ num_files=$( \
          --stats \
         --log-file=/tmp/archive-rsync-cmd.log \
         "${src}/${extpath}"/* \
-        $user@$server:$path \
+        "$user@$server:$path" \
       | awk '/files transferred/{print $NF}'
 )
 
-if (( $num_files > 0 ))
+if (( num_files > 0 ))
 then
   log "${op_future} ${extpath} clips to archive via rsync finished."
   /root/bin/send-push-message "TeslaUSB:" "${op_past} ${num_files} dashcam files"

--- a/run/send-push-message
+++ b/run/send-push-message
@@ -1,7 +1,7 @@
 #!/bin/bash -eu
 
-TITLE="$1"
-MESSAGE="$2"
+readonly TITLE="$1"
+readonly MESSAGE="$2"
 
 function log () {
   echo -n "$( date ): " >> "$LOG_FILE"
@@ -13,11 +13,12 @@ function send_pushover () {
 
   source /root/.teslaCamPushoverCredentials
 
+  # shellcheck disable=SC2154
   curl -F "token=$pushover_app_key" \
-  -F "user=$pushover_user_key" \
-  -F "title=$TITLE" \
-  -F "message=$MESSAGE" \
-  https://api.pushover.net/1/messages
+      -F "user=$pushover_user_key" \
+      -F "title=$TITLE" \
+      -F "message=$MESSAGE" \
+      https://api.pushover.net/1/messages
 }
 
 function send_gotify () {
@@ -25,11 +26,12 @@ function send_gotify () {
 
   source /root/.teslaCamGotifySettings
 
+  # shellcheck disable=SC2154
   curl -X POST \
-  -F "title=$TITLE" \
-  -F "message=$MESSAGE" \
-  -F "priority=$gotify_priority" \
-  "$gotify_domain/message?token=$gotify_app_token"
+      -F "title=$TITLE" \
+      -F "message=$MESSAGE" \
+      -F "priority=$gotify_priority" \
+      "$gotify_domain/message?token=$gotify_app_token"
 }
 
 function send_ifttt () {
@@ -37,10 +39,11 @@ function send_ifttt () {
 
   source /root/.teslaCamIftttSettings
 
+  # shellcheck disable=SC2154
   curl -X POST \
-  -F "value1=$TITLE" \
-  -F "value2=$MESSAGE" \
-  "https://maker.ifttt.com/trigger/$ifttt_event_name/with/key/$ifttt_key"
+      -F "value1=$TITLE" \
+      -F "value2=$MESSAGE" \
+      "https://maker.ifttt.com/trigger/$ifttt_event_name/with/key/$ifttt_key"
 }
 
 function send_sns () {
@@ -48,7 +51,8 @@ function send_sns () {
 
   source /root/.teslaCamSNSTopicARN
 
-  python3 /root/bin/send_sns.py -t $sns_topic_arn -s "$TITLE" -m "$MESSAGE"
+  # shellcheck disable=SC2154
+  python3 /root/bin/send_sns.py -t "$sns_topic_arn" -s "$TITLE" -m "$MESSAGE"
 }
 
 [ -r "/root/.teslaCamPushoverCredentials" ] && send_pushover

--- a/setup/macos_linux/setup-piForHeadlessConfig.sh
+++ b/setup/macos_linux/setup-piForHeadlessConfig.sh
@@ -1,4 +1,4 @@
-#/bin/bash -eu
+#!/bin/bash -eu
 
 # This script will modify the cmdline.txt file on a freshly flashed Raspbian Stretch/Lite
 # It readies it for SSH, USB OTG, USB networking, and Wifi
@@ -31,7 +31,7 @@ function verify_file_exists () {
 }
 
 function verify_wifi_variables () {
-  if [ ! -n "${SSID+x}" ] || [ ! -n "${WIFIPASS+x}"  ]
+  if [ -z "${SSID:+x}" ] || [ -z "${WIFIPASS:+x}"  ]
   then
     echo 'STOP: You need to specify your wifi name and password first. Run: '
     echo " "
@@ -51,7 +51,7 @@ verify_wifi_variables
 CMDLINE_TXT_PATH="$BOOT_DIR/cmdline.txt"
 CONFIG_TXT_PATH="$BOOT_DIR/config.txt"
 
-if ! grep -q "dtoverlay=dwc2" $CONFIG_TXT_PATH
+if ! grep -q "dtoverlay=dwc2" "$CONFIG_TXT_PATH"
 then
    echo "Updating $CONFIG_TXT_PATH ..."
    echo "" >> "$CONFIG_TXT_PATH"
@@ -60,7 +60,7 @@ else
    echo "$CONFIG_TXT_PATH already contains the required dwc2 module"
 fi
 
-if ! grep -q "dwc2,g_ether" $CMDLINE_TXT_PATH
+if ! grep -q "dwc2,g_ether" "$CMDLINE_TXT_PATH"
 then
   echo "Updating $CMDLINE_TXT_PATH ..."
   sed -i'.bak' -e "s/rootwait/rootwait modules-load=dwc2,g_ether/" -e "s@ init=/usr/lib/raspi-config/init_resize.sh@@" "$CMDLINE_TXT_PATH"

--- a/setup/pi/configure-ap.sh
+++ b/setup/pi/configure-ap.sh
@@ -3,6 +3,7 @@
 # based on https://blog.thewalr.us/2017/09/26/raspberry-pi-zero-w-simultaneous-ap-and-managed-mode-wifi/
 
 function log_progress () {
+  # shellcheck disable=SC2034
   if typeset -f setup_progress > /dev/null; then
     setup_progress "configure-ap: $1"
   fi
@@ -24,7 +25,7 @@ fi
 if ! grep -q id_str /etc/wpa_supplicant/wpa_supplicant.conf
 then
   IP=${AP_IP:-"192.168.66.1"}
-  NET=$(echo -n $IP | sed -e 's/\.[0-9]\{1,3\}$//')
+  NET=$(echo -n "$IP" | sed -e 's/\.[0-9]\{1,3\}$//')
 
   # install required packages
   log_progress "installing dnsmasq and hostapd"

--- a/setup/pi/configure-samba.sh
+++ b/setup/pi/configure-samba.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 function log_progress () {
+  # shellcheck disable=SC2034
   if typeset -f setup_progress > /dev/null; then
     setup_progress "configure-samba: $1"
   fi

--- a/setup/pi/configure.sh
+++ b/setup/pi/configure.sh
@@ -224,7 +224,7 @@ function check_ifttt_configuration () {
 function check_sns_configuration () {
     if [ ! -z "${sns_enabled+x}" ]
     then
-        if [ ! -n "${aws_access_key_id+x}" ] || [ ! -n "${aws_secret_key+x}" || [ ! -n "${aws_sns_topic_arn+x}"  ]
+        if [ ! -n "${aws_access_key_id+x}" ] || [ ! -n "${aws_secret_key+x}" ] || [ ! -n "${aws_sns_topic_arn+x}"  ]
         then
             echo "STOP: You're trying to setup AWS SNS but didn't provide your User and/or App key and/or topic ARN."
             echo "Define the variables like this:"
@@ -232,7 +232,7 @@ function check_sns_configuration () {
             echo "export aws_secret_key=put_your_secretkey_here"
             echo "export aws_sns_topic_arn=put_your_sns_topicarn_here"
             exit 1
-        elif [ "${aws_access_key_id}" = "put_your_accesskeyid_here" ] || [  "${aws_secret_key}" = "put_your_secretkey_here"  || [  "${aws_sns_topic_arn}" = "put_your_sns_topicarn_here" ]
+        elif [ "${aws_access_key_id}" = "put_your_accesskeyid_here" ] || [  "${aws_secret_key}" = "put_your_secretkey_here" ] || [  "${aws_sns_topic_arn}" = "put_your_sns_topicarn_here" ]
         then
             echo "STOP: You're trying to setup SNS, but didn't replace the default values."
             exit 1
@@ -348,9 +348,12 @@ check_archive_configs
 
 configFile=/root/teslausb.conf
 
-echo "ARCHIVE_HOST_NAME=$archiveserver" > $configFile
-echo "ARCHIVE_DELAY=${archivedelay:-20}" >> $configFile
-echo "SNAPSHOTS_ENABLED=${SNAPSHOTS_ENABLED:-true}" >> $configFile
+{
+  echo "ARCHIVE_HOST_NAME=$archiveserver"
+  echo "ARCHIVE_DELAY=${archivedelay:-20}"
+  echo "SNAPSHOTS_ENABLED=${SNAPSHOTS_ENABLED:-true}"
+  echo "ARCHIVE_RECENT_CLIPS=${ARCHIVE_RECENT_CLIPS:-false}"
+} > $configFile
 
 archive_module="$( get_archive_module )"
 log_progress "Using archive module: $archive_module"

--- a/setup/pi/configure.sh
+++ b/setup/pi/configure.sh
@@ -355,6 +355,7 @@ configFile=/root/teslausb.conf
   echo "ARCHIVE_DELAY=${archivedelay:-20}"
   echo "SNAPSHOTS_ENABLED=${SNAPSHOTS_ENABLED:-true}"
   echo "ARCHIVE_RECENT_CLIPS=${ARCHIVE_RECENT_CLIPS:-false}"
+  echo "ENABLE_CAM_AND_MUSIC_DRIVES_DURING_RECENT_ARCHIVE=${ENABLE_CAM_AND_MUSIC_DRIVES_DURING_RECENT_ARCHIVE:-false}"
 } > $configFile
 
 archive_module="$(get_archive_module)"

--- a/setup/pi/configure.sh
+++ b/setup/pi/configure.sh
@@ -1,20 +1,19 @@
 #!/bin/bash -eu
 
-if [ "$BASH_SOURCE" != "$0" ]
-then
-  echo "$BASH_SOURCE must be executed, not sourced"
+if [ "${BASH_SOURCE[0]}" != "$0" ]; then
+  echo "${BASH_SOURCE[0]} must be executed, not sourced"
   return 1 # shouldn't use exit when sourced
 fi
 
-function log_progress () {
-  if typeset -f setup_progress > /dev/null; then
+function log_progress() {
+  # shellcheck disable=SC2034
+  if typeset -f setup_progress >/dev/null; then
     setup_progress "configure: $1"
   fi
   echo "configure: $1"
 }
 
-if [ "${FLOCKED:-}" != "$0" ]
-then
+if [ "${FLOCKED:-}" != "$0" ]; then
   PARENT="$(ps -o comm= $PPID)"
   if [ "$PARENT" != "setup-teslausb" ]
   then
@@ -23,13 +22,14 @@ then
   fi
 
   if FLOCKED="$0" flock -en -E 99 "$0" "$0" "$@" || case "$?" in
-  99) echo already running
-      exit 99
-      ;;
-  *)  exit $?
-      ;;
-  esac
-  then
+  99)
+    echo already running
+    exit 99
+    ;;
+  *)
+    exit $?
+    ;;
+  esac then
     # success
     exit 0
   fi
@@ -47,18 +47,17 @@ function check_variable () {
 }
 
 function install_rc_local () {
-    local install_home="$1"
+  local install_home="$1"
 
-    if grep -q archiveloop /etc/rc.local
-    then
-        log_progress "Skipping rc.local installation"
-        return
-    fi
+  if grep -q archiveloop /etc/rc.local; then
+    log_progress "Skipping rc.local installation"
+    return
+  fi
 
-    log_progress "Configuring /etc/rc.local to run the archive scripts at startup..."
-    echo "#!/bin/bash -eu" > ~/rc.local
-    echo "install_home=\"${install_home}\"" >> ~/rc.local
-    cat << 'EOF' >> ~/rc.local
+  log_progress "Configuring /etc/rc.local to run the archive scripts at startup..."
+  echo "#!/bin/bash -eu" >~/rc.local
+  echo "install_home=\"${install_home}\"" >>~/rc.local
+  cat <<'EOF' >>~/rc.local
 LOGFILE=/tmp/rc.local.log
 
 function log () {
@@ -72,268 +71,272 @@ log "All done"
 exit 0
 EOF
 
-    cat ~/rc.local > /etc/rc.local
-    rm ~/rc.local
-    log_progress "Installed rc.local."
+  cat ~/rc.local >/etc/rc.local
+  rm ~/rc.local
+  log_progress "Installed rc.local."
 }
 
-function check_archive_configs () {
-    log_progress "Checking archive configs: "
+function check_archive_configs() {
+  log_progress "Checking archive configs: "
 
-    case "$ARCHIVE_SYSTEM" in
-        rsync)
-            check_variable "RSYNC_USER"
-            check_variable "RSYNC_SERVER"
-            check_variable "RSYNC_PATH"
-            export archiveserver="$RSYNC_SERVER"
-            ;;
-        rclone)
-            check_variable "RCLONE_DRIVE"
-            check_variable "RCLONE_PATH"
-            export archiveserver="8.8.8.8" # since it's a cloud hosted drive we'll just set this to google dns
-            ;;
-        cifs)
-            check_variable "sharename"
-            check_variable "shareuser"
-            check_variable "sharepassword"
-            check_variable "archiveserver"
-            ;;
-        none)
-            export archiveserver=localhost
-            ;;
-        *)
-            log_progress "STOP: Unrecognized archive system: $ARCHIVE_SYSTEM"
-            exit 1
-            ;;
-    esac
+  case "$ARCHIVE_SYSTEM" in
+  rsync)
+    check_variable "RSYNC_USER"
+    check_variable "RSYNC_SERVER"
+    check_variable "RSYNC_PATH"
+    export archiveserver="$RSYNC_SERVER"
+    ;;
+  rclone)
+    check_variable "RCLONE_DRIVE"
+    check_variable "RCLONE_PATH"
+    export archiveserver="8.8.8.8" # since it's a cloud hosted drive we'll just set this to google dns
+    ;;
+  cifs)
+    check_variable "sharename"
+    check_variable "shareuser"
+    check_variable "sharepassword"
+    check_variable "archiveserver"
+    ;;
+  none)
+    export archiveserver=localhost
+    ;;
+  *)
+    log_progress "STOP: Unrecognized archive system: $ARCHIVE_SYSTEM"
+    exit 1
+    ;;
+  esac
 
-    log_progress "done"
+  log_progress "done"
 }
 
-function get_archive_module () {
+function get_archive_module() {
 
-    case "$ARCHIVE_SYSTEM" in
-        rsync)
-            echo "run/rsync_archive"
-            ;;
-        rclone)
-            echo "run/rclone_archive"
-            ;;
-        cifs)
-            echo "run/cifs_archive"
-            ;;
-        none)
-            echo "run/none_archive"
-            ;;
-        *)
-            log_progress "Internal error: Attempting to configure unrecognized archive system: $ARCHIVE_SYSTEM"
-            exit 1
-            ;;
-    esac
+  case "$ARCHIVE_SYSTEM" in
+  rsync)
+    echo "run/rsync_archive"
+    ;;
+  rclone)
+    echo "run/rclone_archive"
+    ;;
+  cifs)
+    echo "run/cifs_archive"
+    ;;
+  none)
+    echo "run/none_archive"
+    ;;
+  *)
+    log_progress "Internal error: Attempting to configure unrecognized archive system: $ARCHIVE_SYSTEM"
+    exit 1
+    ;;
+  esac
 }
 
-function install_archive_scripts () {
-    local install_path="$1"
-    local archive_module="$2"
+function install_archive_scripts() {
+  local install_path="$1"
+  local archive_module="$2"
 
-    log_progress "Installing base archive scripts into $install_path"
-    get_script $install_path archiveloop run
-    get_script $install_path remountfs_rw run
-    # Install the tesla_api.py script only if the user provided credentials for its use.
-    if [ ! -z ${tesla_email:+x} ]
-    then
-      get_script $install_path tesla_api.py run
-    else
-      log_progress "Skipping tesla_api.py install"
-    fi
+  log_progress "Installing base archive scripts into $install_path"
+  get_script "$install_path" archiveloop run
+  get_script "$install_path" remountfs_rw run
+  # Install the tesla_api.py script only if the user provided credentials for its use.
+  # shellcheck disable=SC2154
+  if [ -n "${tesla_email:+x}" ]; then
+    get_script "$install_path" tesla_api.py run
+  else
+    log_progress "Skipping tesla_api.py install"
+  fi
 
-    log_progress "Installing archive module scripts"
-    get_script /tmp verify-and-configure-archive.sh $archive_module
-    get_script $install_path archive-clips.sh $archive_module
-    get_script $install_path connect-archive.sh $archive_module
-    get_script $install_path disconnect-archive.sh $archive_module
-    get_script $install_path write-archive-configs-to.sh $archive_module
-    get_script $install_path archive-is-reachable.sh $archive_module
-    if [ ! -z ${musicsharename:+x} ]
-    then
-      get_script $install_path copy-music.sh $archive_module
-    fi
+  log_progress "Installing archive module scripts"
+  get_script /tmp verify-and-configure-archive.sh "$archive_module"
+  get_script "$install_path" archive-clips.sh "$archive_module"
+  get_script "$install_path" connect-archive.sh "$archive_module"
+  get_script "$install_path" disconnect-archive.sh "$archive_module"
+  get_script "$install_path" write-archive-configs-to.sh "$archive_module"
+  get_script "$install_path" archive-is-reachable.sh "$archive_module"
+  # shellcheck disable=SC2154
+  if [ -n "${musicsharename:+x}" ]; then
+    get_script "$install_path" copy-music.sh "$archive_module"
+  fi
 }
 
-
-function install_python_packages () {
+function install_python_packages() {
   setup_progress "Installing python packages..."
   apt-get --assume-yes install python3-pip
   pip3 install boto3
 }
 
-function check_pushover_configuration () {
-    if [ ! -z "${pushover_enabled+x}" ]
-    then
-        if [ ! -n "${pushover_user_key+x}" ] || [ ! -n "${pushover_app_key+x}"  ]
-        then
-            log_progress "STOP: You're trying to setup Pushover but didn't provide your User and/or App key."
-            log_progress "Define the variables like this:"
-            log_progress "export pushover_user_key=put_your_userkey_here"
-            log_progress "export pushover_app_key=put_your_appkey_here"
-            exit 1
-        elif [ "${pushover_user_key}" = "put_your_userkey_here" ] || [  "${pushover_app_key}" = "put_your_appkey_here" ]
-        then
-            log_progress "STOP: You're trying to setup Pushover, but didn't replace the default User and App key values."
-            exit 1
-        fi
+function check_pushover_configuration() {
+  # shellcheck disable=SC2154
+  if [ -n "${pushover_enabled:+x}" ]; then
+    # shellcheck disable=SC2154
+    if [ -z "${pushover_user_key:+x}" ] || [ -z "${pushover_app_key:+x}" ]; then
+      log_progress "STOP: You're trying to setup Pushover but didn't provide your User and/or App key."
+      log_progress "Define the variables like this:"
+      log_progress "export pushover_user_key=put_your_userkey_here"
+      log_progress "export pushover_app_key=put_your_appkey_here"
+      exit 1
+    elif [ "${pushover_user_key}" = "put_your_userkey_here" ] || [ "${pushover_app_key}" = "put_your_appkey_here" ]; then
+      log_progress "STOP: You're trying to setup Pushover, but didn't replace the default User and App key values."
+      exit 1
     fi
+  fi
 }
 
-function check_gotify_configuration () {
-    if [ ! -z "${gotify_enabled+x}" ]
-    then
-        if [ ! -n "${gotify_domain+x}" ] || [ ! -n "${gotify_app_token+x}"  ]
-        then
-            log_progress "STOP: You're trying to setup Gotify but didn't provide your Domain and/or App token."
-            log_progress "Define the variables like this:"
-            log_progress "export gotify_domain=https://gotify.domain.com"
-            log_progress "export gotify_app_token=put_your_token_here"
-            exit 1
-        elif [ "${gotify_domain}" = "https://gotify.domain.com" ] || [  "${gotify_app_token}" = "put_your_token_here" ]
-        then
-            log_progress "STOP: You're trying to setup Gotify, but didn't replace the default Domain and/or App token values."
-            exit 1
-        fi
+function check_gotify_configuration() {
+  # shellcheck disable=SC2154
+  if [ -n "${gotify_enabled:+x}" ]; then
+    # shellcheck disable=SC2154
+    if [ -z "${gotify_domain:+x}" ] || [ -z "${gotify_app_token:+x}" ]; then
+      log_progress "STOP: You're trying to setup Gotify but didn't provide your Domain and/or App token."
+      log_progress "Define the variables like this:"
+      log_progress "export gotify_domain=https://gotify.domain.com"
+      log_progress "export gotify_app_token=put_your_token_here"
+      exit 1
+    elif [ "${gotify_domain}" = "https://gotify.domain.com" ] || [ "${gotify_app_token}" = "put_your_token_here" ]; then
+      log_progress "STOP: You're trying to setup Gotify, but didn't replace the default Domain and/or App token values."
+      exit 1
     fi
+  fi
 }
 
-function check_ifttt_configuration () {
-    if [ ! -z "${ifttt_enabled+x}" ]
-    then
-        if [ ! -n "${ifttt_event_name+x}" ] || [ ! -n "${ifttt_key+x}"  ]
-        then
-            log_progress "STOP: You're trying to setup IFTTT but didn't provide your Event Name and/or key."
-            log_progress "Define the variables like this:"
-            log_progress "export ifttt_event_name=put_your_event_name_here"
-            log_progress "export ifttt_key=put_your_key_here"
-            exit 1
-        elif [ "${ifttt_event_name}" = "put_your_event_name_here" ] || [  "${ifttt_key}" = "put_your_key_here" ]
-        then
-            log_progress "STOP: You're trying to setup IFTTT, but didn't replace the default Event Name and/or key values."
-            exit 1
-        fi
+function check_ifttt_configuration() {
+  # shellcheck disable=SC2154
+  if [ -n "${ifttt_enabled:+x}" ]; then
+    # shellcheck disable=SC2154
+    if [ -z "${ifttt_event_name:+x}" ] || [ -z "${ifttt_key:+x}" ]; then
+      log_progress "STOP: You're trying to setup IFTTT but didn't provide your Event Name and/or key."
+      log_progress "Define the variables like this:"
+      log_progress "export ifttt_event_name=put_your_event_name_here"
+      log_progress "export ifttt_key=put_your_key_here"
+      exit 1
+    elif [ "${ifttt_event_name}" = "put_your_event_name_here" ] || [ "${ifttt_key}" = "put_your_key_here" ]; then
+      log_progress "STOP: You're trying to setup IFTTT, but didn't replace the default Event Name and/or key values."
+      exit 1
     fi
+  fi
 }
 
-function check_sns_configuration () {
-    if [ ! -z "${sns_enabled+x}" ]
-    then
-        if [ ! -n "${aws_access_key_id+x}" ] || [ ! -n "${aws_secret_key+x}" ] || [ ! -n "${aws_sns_topic_arn+x}"  ]
-        then
-            echo "STOP: You're trying to setup AWS SNS but didn't provide your User and/or App key and/or topic ARN."
-            echo "Define the variables like this:"
-            echo "export aws_access_key_id=put_your_accesskeyid_here"
-            echo "export aws_secret_key=put_your_secretkey_here"
-            echo "export aws_sns_topic_arn=put_your_sns_topicarn_here"
-            exit 1
-        elif [ "${aws_access_key_id}" = "put_your_accesskeyid_here" ] || [  "${aws_secret_key}" = "put_your_secretkey_here" ] || [  "${aws_sns_topic_arn}" = "put_your_sns_topicarn_here" ]
-        then
-            echo "STOP: You're trying to setup SNS, but didn't replace the default values."
-            exit 1
-        fi
+function check_sns_configuration() {
+  # shellcheck disable=SC2154
+  if [ -n "${sns_enabled:+x}" ]; then
+    # shellcheck disable=SC2154
+    if [ -z "${aws_access_key_id:+x}" ] || [ -z "${aws_secret_key:+x}" ] || [ -z "${aws_sns_topic_arn:+x}" ]; then
+      echo "STOP: You're trying to setup AWS SNS but didn't provide your User and/or App key and/or topic ARN."
+      echo "Define the variables like this:"
+      echo "export aws_access_key_id=put_your_accesskeyid_here"
+      echo "export aws_secret_key=put_your_secretkey_here"
+      echo "export aws_sns_topic_arn=put_your_sns_topicarn_here"
+      exit 1
+    elif [ "${aws_access_key_id}" = "put_your_accesskeyid_here" ] || [ "${aws_secret_key}" = "put_your_secretkey_here" ] || [ "${aws_sns_topic_arn}" = "put_your_sns_topicarn_here" ]; then
+      echo "STOP: You're trying to setup SNS, but didn't replace the default values."
+      exit 1
     fi
+  fi
 }
 
-function configure_pushover () {
-    if [ ! -z "${pushover_enabled+x}" ]
-    then
-        log_progress "Enabling pushover"
-        echo "export pushover_enabled=true" > /root/.teslaCamPushoverCredentials
-        echo "export pushover_user_key=$pushover_user_key" >> /root/.teslaCamPushoverCredentials
-        echo "export pushover_app_key=$pushover_app_key" >> /root/.teslaCamPushoverCredentials
-    else
-        log_progress "Pushover not configured."
-    fi
+function configure_pushover() {
+  if [ -n "${pushover_enabled:+x}" ]; then
+    log_progress "Enabling pushover"
+    {
+      echo "export pushover_enabled=true"
+      echo "export pushover_user_key=$pushover_user_key"
+      echo "export pushover_app_key=$pushover_app_key"
+    } >/root/.teslaCamPushoverCredentials
+  else
+    log_progress "Pushover not configured."
+  fi
 }
 
-function configure_gotify () {
-    if [ ! -z "${gotify_enabled+x}" ]
-    then
-        log_progress "Enabling Gotify"
-        echo "export gotify_enabled=true" > /root/.teslaCamGotifySettings
-        echo "export gotify_domain=$gotify_domain" >> /root/.teslaCamGotifySettings
-        echo "export gotify_app_token=$gotify_app_token" >> /root/.teslaCamGotifySettings
-        echo "export gotify_priority=$gotify_priority" >> /root/.teslaCamGotifySettings
-    else
-        log_progress "Gotify not configured."
-    fi
+function configure_gotify() {
+  if [ -n "${gotify_enabled:+x}" ]; then
+    log_progress "Enabling Gotify"
+    # shellcheck disable=SC2154
+    {
+      echo "export gotify_enabled=true"
+      echo "export gotify_domain=$gotify_domain"
+      echo "export gotify_app_token=$gotify_app_token"
+      echo "export gotify_priority=$gotify_priority"
+    } >/root/.teslaCamGotifySettings
+  else
+    log_progress "Gotify not configured."
+  fi
 }
 
-function configure_ifttt () {
-    if [ ! -z "${ifttt_enabled+x}" ]
-    then
-        log_progress "Enabling IFTTT"
-        echo "export ifttt_enabled=true" > /root/.teslaCamIftttSettings
-        echo "export ifttt_event_name=$ifttt_event_name" >> /root/.teslaCamIftttSettings
-        echo "export ifttt_key=$ifttt_key" >> /root/.teslaCamIftttSettings
-    else
-        log_progress "IFTTT not configured."
-    fi
+function configure_ifttt() {
+  if [ -n "${ifttt_enabled:+x}" ]; then
+    log_progress "Enabling IFTTT"
+    {
+      echo "export ifttt_enabled=true"
+      echo "export ifttt_event_name=$ifttt_event_name"
+      echo "export ifttt_key=$ifttt_key"
+    } > /root/.teslaCamIftttSettings
+  else
+    log_progress "Gotify not configured."
+  fi
 }
 
-function configure_sns () {
-    if [ ! -z "${sns_enabled+x}" ]
-    then
-        log_progress "Enabling SNS"
-        mkdir /root/.aws
+function configure_sns() {
+  if [ -n "${sns_enabled:+x}" ]; then
+    echo "Enabling SNS"
+    mkdir /root/.aws
 
-        echo "[default]" > /root/.aws/credentials
-        echo "aws_access_key_id = $aws_access_key_id" >> /root/.aws/credentials
-        echo "aws_secret_access_key = $aws_secret_key" >> /root/.aws/credentials
+    {
+      echo "[default]"
+      echo "aws_access_key_id = $aws_access_key_id"
+      echo "aws_secret_access_key = $aws_secret_key"
+    } > /root/.aws/credentials
 
-        echo "[default]" > /root/.aws/config
-        echo "region = $aws_region" >> /root/.aws/config
+    # shellcheck disable=SC2154
+    {
+      echo "[default]"
+      echo "region = $aws_region"
+    } > /root/.aws/config
 
-        echo "export sns_enabled=true" > /root/.teslaCamSNSTopicARN
-        echo "export sns_topic_arn=$aws_sns_topic_arn" >> /root/.teslaCamSNSTopicARN
+    {
+      echo "export sns_enabled=true"
+      echo "export sns_topic_arn=$aws_sns_topic_arn"
+    } > /root/.teslaCamSNSTopicARN
 
-        install_python_packages
-    else
-        log_progress "SNS not configured."
-    fi
+    install_python_packages
+  else
+    echo "SNS not configured."
+  fi
 }
 
-function check_and_configure_pushover () {
-    check_pushover_configuration
+function check_and_configure_pushover() {
+  check_pushover_configuration
 
-    configure_pushover
+  configure_pushover
 }
 
-function check_and_configure_gotify () {
-    check_gotify_configuration
+function check_and_configure_gotify() {
+  check_gotify_configuration
 
-    configure_gotify
+  configure_gotify
 }
 
-function check_and_configure_ifttt () {
-    check_ifttt_configuration
+function check_and_configure_ifttt() {
+  check_ifttt_configuration
 
-    configure_ifttt
+  configure_ifttt
 }
 
+function check_and_configure_sns() {
+  check_sns_configuration
 
-function check_and_configure_sns () {
-    check_sns_configuration
-
-    configure_sns
+  configure_sns
 }
 
 function install_push_message_scripts() {
-    local install_path="$1"
-    get_script $install_path send-push-message run
-    get_script $install_path send_sns.py run
+  local install_path="$1"
+  get_script "$install_path" send-push-message run
+  get_script "$install_path" send_sns.py run
 }
 
-if ! [ $(id -u) = 0 ]
-then
-    log_progress "STOP: Run sudo -i."
-    exit 1
+# shellcheck disable=SC2046
+if ! [ $(id -u) = 0 ]; then
+  log_progress "STOP: Run sudo -i."
+  exit 1
 fi
 
 mkdir -p /root/bin
@@ -347,7 +350,6 @@ install_push_message_scripts /root/bin
 check_archive_configs
 
 configFile=/root/teslausb.conf
-
 {
   echo "ARCHIVE_HOST_NAME=$archiveserver"
   echo "ARCHIVE_DELAY=${archivedelay:-20}"
@@ -355,10 +357,10 @@ configFile=/root/teslausb.conf
   echo "ARCHIVE_RECENT_CLIPS=${ARCHIVE_RECENT_CLIPS:-false}"
 } > $configFile
 
-archive_module="$( get_archive_module )"
+archive_module="$(get_archive_module)"
 log_progress "Using archive module: $archive_module"
 
-install_archive_scripts /root/bin $archive_module
+install_archive_scripts /root/bin "$archive_module"
 /tmp/verify-and-configure-archive.sh
 
 install_rc_local /root/bin

--- a/setup/pi/create-backingfiles-partition.sh
+++ b/setup/pi/create-backingfiles-partition.sh
@@ -3,11 +3,11 @@
 function setup_progress () {
   local setup_logfile=/boot/teslausb-headless-setup.log
   local headless_setup=${HEADLESS_SETUP:-false}
-  if [ $headless_setup = "true" ]
+  if [ "$headless_setup" = "true" ]
   then
     echo "$( date ) : $1" >> "$setup_logfile"
   fi
-  echo $1
+  echo "$1"
 }
 
 # install XFS tools if needed
@@ -17,17 +17,18 @@ then
 fi
 
 # Will check for USB Drive before running sd card
-if [ ! -z "$usb_drive" ]
+# shellcheck disable=SC2154
+if [ -n "$usb_drive" ]
 then
   setup_progress "usb_drive is set to $usb_drive"
   # Check if backingfiles and mutable partitions exist
-  if [ /dev/disk/by-label/backingfiles -ef /dev/sda2 -a /dev/disk/by-label/mutable -ef /dev/sda1 ]
+  if [ /dev/disk/by-label/backingfiles -ef /dev/sda2 ] && [ /dev/disk/by-label/mutable -ef /dev/sda1 ]
   then
     setup_progress "Looks like backingfiles and mutable partitions already exist. Skipping partition creation."
   else
     setup_progress "WARNING !!! This will delete EVERYTHING in $usb_drive."
-    wipefs -afq $usb_drive
-    parted $usb_drive --script mktable gpt
+    wipefs -afq "$usb_drive"
+    parted "$usb_drive" --script mktable gpt
     setup_progress "$usb_drive fully erased. Creating partitions..."
     parted -a optimal -m /dev/sda mkpart primary ext4 '0%' 2GB
     parted -a optimal -m /dev/sda mkpart primary ext4 2GB '100%'
@@ -61,9 +62,9 @@ fi
 
 # If partition 3 is the backingfiles partition, type xfs, and
 # partition 4 the mutable partition, type ext4, then return early.
-if [ /dev/disk/by-label/backingfiles -ef /dev/mmcblk0p3 -a \
-    /dev/disk/by-label/mutable -ef /dev/mmcblk0p4 ] && \
-    blkid /dev/mmcblk0p4 | grep -q 'TYPE="ext4"'
+if [ /dev/disk/by-label/backingfiles -ef /dev/mmcblk0p3 ] \
+   && [ /dev/disk/by-label/mutable -ef /dev/mmcblk0p4 ] \
+   && blkid /dev/mmcblk0p4 | grep -q 'TYPE="ext4"'
 then
   if blkid /dev/mmcblk0p3 | grep -q 'TYPE="xfs"'
   then
@@ -104,7 +105,7 @@ then
 fi
 
 # partition 3 and 4 either don't exist, or are the wrong type
-if [ -e /dev/mmcblk0p3 -o -e /dev/mmcblk0p4 ]
+if [ -e /dev/mmcblk0p3 ] || [ -e /dev/mmcblk0p4 ]
 then
   setup_progress "STOP: partitions already exist, but are not as expected"
   setup_progress "please delete them and re-run setup"
@@ -117,13 +118,13 @@ MUTABLE_MOUNTPOINT="$2"
 setup_progress "Checking existing partitions..."
 
 DISK_SECTORS=$(blockdev --getsz /dev/mmcblk0)
-LAST_DISK_SECTOR=$(($DISK_SECTORS-1))
+LAST_DISK_SECTOR=$((DISK_SECTORS-1))
 # mutable partition is 100MB at the end of the disk, calculate its start sector
 FIRST_MUTABLE_SECTOR=$((LAST_DISK_SECTOR-204800+1))
 # backingfiles partition sits between the root and mutable partition, calculate its start sector and size
 LAST_ROOT_SECTOR=$(sfdisk -l /dev/mmcblk0 | grep mmcblk0p2 | awk '{print $3}')
 FIRST_BACKINGFILES_SECTOR=$((LAST_ROOT_SECTOR+1))
-BACKINGFILES_NUM_SECTORS=$((FIRST_MUTABLE_SECTOR-$FIRST_BACKINGFILES_SECTOR))
+BACKINGFILES_NUM_SECTORS=$((FIRST_MUTABLE_SECTOR-FIRST_BACKINGFILES_SECTOR))
 
 ORIGINAL_DISK_IDENTIFIER=$( fdisk -l /dev/mmcblk0 | grep -e "^Disk identifier" | sed "s/Disk identifier: 0x//" )
 
@@ -134,11 +135,11 @@ setup_progress "Modifying partition table for mutable (writable) partition for s
 echo "$FIRST_MUTABLE_SECTOR," | sfdisk --force /dev/mmcblk0 -N 4
 
 # manually adding the partitions to the kernel's view of things is sometimes needed
-if [ ! -e /dev/mmcblk0p3 -o ! -e /dev/mmcblk0p4 ]
+if [ ! -e /dev/mmcblk0p3 ] || [ ! -e /dev/mmcblk0p4 ]
 then
   partx --add --nr 3:4 /dev/mmcblk0
 fi
-if [ ! -e /dev/mmcblk0p3 -o ! -e /dev/mmcblk0p4 ]
+if [ ! -e /dev/mmcblk0p3 ] || [ ! -e /dev/mmcblk0p4 ]
 then
   setup_progress "failed to add partitions"
   exit 1

--- a/setup/pi/create-backingfiles.sh
+++ b/setup/pi/create-backingfiles.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -eu
 
 function log_progress () {
+  # shellcheck disable=SC2034
   if typeset -f setup_progress > /dev/null; then
     setup_progress "create-backingfiles: $1"
   fi
@@ -12,7 +13,7 @@ log_progress "starting"
 CAM_SIZE="$1"
 MUSIC_SIZE="$2"
 # strip trailing slash that shell autocomplete might have added
-BACKINGFILES_MOUNTPOINT=$(echo "$3" | sed 's@/$@@')
+BACKINGFILES_MOUNTPOINT="${3//\//}"
 
 log_progress "cam: $CAM_SIZE, music: $MUSIC_SIZE, mountpoint: $BACKINGFILES_MOUNTPOINT"
 
@@ -20,17 +21,23 @@ G_MASS_STORAGE_CONF_FILE_NAME=/etc/modprobe.d/g_mass_storage.conf
 
 function first_partition_offset () {
   local filename="$1"
-  local size_in_bytes=$(sfdisk -l -o Size -q --bytes "$1" | tail -1)
-  local size_in_sectors=$(sfdisk -l -o Sectors -q "$1" | tail -1)
-  local sector_size=$(($size_in_bytes/$size_in_sectors))
-  local partition_start_sector=$(sfdisk -l -o Start -q "$1" | tail -1)
-  echo $(($partition_start_sector*$sector_size))
+  local size_in_bytes
+  local size_in_sectors
+  local sector_size
+  local partition_start_sector
+
+  size_in_bytes=$(sfdisk -l -o Size -q --bytes "$1" | tail -1)
+  size_in_sectors=$(sfdisk -l -o Sectors -q "$1" | tail -1)
+  sector_size=$((size_in_bytes/size_in_sectors))
+  partition_start_sector=$(sfdisk -l -o Start -q "$1" | tail -1)
+
+  echo $((partition_start_sector*sector_size))
 }
 
 # Note that this uses powers-of-two rather than the powers-of-ten that are
 # generally used to market storage.
 function dehumanize () {
-  echo $(($(echo $1 | sed 's/G/*1024M/;s/M/*1024K/;s/K/*1024/')))
+  echo $(($(echo "$1" | sed 's/G/*1024M/;s/M/*1024K/;s/K/*1024/')))
 }
 
 function is_percent() {
@@ -38,7 +45,7 @@ function is_percent() {
 }
 
 available_space () {
-  freespace=$(df --output=avail --block-size=1K $BACKINGFILES_MOUNTPOINT/ | tail -n 1)
+  freespace=$(df --output=avail --block-size=1K "$BACKINGFILES_MOUNTPOINT/" | tail -n 1)
   # leave 6 GB of free space for filesystem bookkeeping and snapshotting
   # (in kilobytes so 6M KB)
   # TODO: investigate whether this value can be smaller in general, or
@@ -49,7 +56,8 @@ available_space () {
 
 function calc_size () {
   local requestedsize="$1"
-  local availablesize="$(available_space)"
+  local availablesize
+  availablesize=$(available_space)
   if [ "$availablesize" -lt 0 ]
   then
     echo "0"
@@ -57,8 +65,8 @@ function calc_size () {
   fi
   if is_percent "$requestedsize"
   then
-    local percent=$(echo $requestedsize | sed 's/%//')
-    requestedsize="$(( $availablesize * $percent / 100 ))"
+    local percent=${requestedsize//%/}
+    requestedsize="$(( availablesize * percent / 100 ))"
   else
     requestedsize="$(( $(dehumanize $requestedsize) / 1024 ))"
   fi
@@ -66,7 +74,7 @@ function calc_size () {
   then
     requestedsize="$availablesize"
   fi
-  echo $requestedsize
+  echo "$requestedsize"
 }
 
 function add_drive () {
@@ -75,17 +83,19 @@ function add_drive () {
   local size="$3"
   local filename="$4"
 
+  local partition_offset
+
   log_progress "Allocating ${size}K for $filename..."
   fallocate -l "$size"K "$filename"
   echo "type=c" | sfdisk "$filename" > /dev/null
-  local partition_offset=$(first_partition_offset "$filename")
-  losetup -o $partition_offset -f "$filename"
+  partition_offset=$(first_partition_offset "$filename")
+  losetup -o "$partition_offset" -f "$filename"
   loopdev=$(losetup -j "$filename" | awk '{print $1}' | sed 's/://')
   log_progress "Creating filesystem with label '$label'"
-  mkfs.vfat $loopdev -F 32 -n "$label"
-  losetup -d $loopdev
+  mkfs.vfat "$loopdev" -F 32 -n "$label"
+  losetup -d "$loopdev"
 
-  local mountpoint=/mnt/"$name"
+  local mountpoint="/mnt/$name"
 
   if [ ! -e "$mountpoint" ]
   then
@@ -109,7 +119,7 @@ MUSIC_DISK_FILE_NAME="$BACKINGFILES_MOUNTPOINT/music_disk.bin"
 # because they interfere with the percentage-of-free-space calculation
 if [ -t 0 ]
 then
-  read -p 'Delete snapshots and recreate recording and music drives? (yes/cancel)' answer
+  read -r -p 'Delete snapshots and recreate recording and music drives? (yes/cancel)' answer
   case ${answer:0:1} in
     y|Y )
     ;;
@@ -128,8 +138,8 @@ rm -f "$CAM_DISK_FILE_NAME"
 rm -f "$MUSIC_DISK_FILE_NAME"
 rm -rf "$BACKINGFILES_MOUNTPOINT/snapshots"
 
-CAM_DISK_SIZE="$(calc_size $CAM_SIZE)"
-MUSIC_DISK_SIZE="$(calc_size $MUSIC_SIZE)"
+CAM_DISK_SIZE="$(calc_size "$CAM_SIZE")"
+MUSIC_DISK_SIZE="$(calc_size "$MUSIC_SIZE")"
 
 add_drive "cam" "CAM" "$CAM_DISK_SIZE" "$CAM_DISK_FILE_NAME"
 log_progress "created camera backing file"
@@ -144,7 +154,7 @@ then
   MUSIC_DISK_SIZE="$REMAINING_SPACE"
 fi
 
-if [ "$REMAINING_SPACE" -ge 1024 -a "$MUSIC_DISK_SIZE" -gt 0 ]
+if [ "$REMAINING_SPACE" -ge 1024 ] && [ "$MUSIC_DISK_SIZE" -gt 0 ]
 then
   add_drive "music" "MUSIC" "$MUSIC_DISK_SIZE" "$MUSIC_DISK_FILE_NAME"
   log_progress "created music backing file"

--- a/setup/pi/make-root-fs-readonly.sh
+++ b/setup/pi/make-root-fs-readonly.sh
@@ -37,6 +37,7 @@ log_progress "Configuring system..."
 append_cmdline_txt_param fastboot
 append_cmdline_txt_param noswap
 append_cmdline_txt_param ro
+append_cmdline_txt_param dtoverlay=sdio,poll_once
 
 # we're not using swap, so delete the swap file for some extra space
 rm -f /var/swap

--- a/setup/pi/make-root-fs-readonly.sh
+++ b/setup/pi/make-root-fs-readonly.sh
@@ -3,6 +3,7 @@
 # Adapted from https://github.com/adafruit/Raspberry-Pi-Installer-Scripts/blob/master/read-only-fs.sh
 
 function log_progress () {
+  # shellcheck disable=SC2034
   if typeset -f setup_progress > /dev/null; then
     setup_progress "make-root-fs-readonly: $1"
   fi

--- a/setup/pi/setup-teslausb
+++ b/setup/pi/setup-teslausb
@@ -224,6 +224,8 @@ function get_common_scripts () {
   get_script /root/bin mount_image.sh run
   get_script /root/bin release_snapshot.sh run
   get_script /root/bin force_sync.sh run
+  get_script /root/bin make_music_snapshot.sh run
+  get_script /root/bin release_music_snapshot.sh run
 }
 
 function fix_cmdline_txt_modules_load ()

--- a/setup/pi/setup-teslausb
+++ b/setup/pi/setup-teslausb
@@ -1,8 +1,8 @@
 #!/bin/bash -eu
 
-if [ "$BASH_SOURCE" != "$0" ]
+if [ "${BASH_SOURCE[0]}" != "$0" ]
 then
-  echo "$BASH_SOURCE must be executed, not sourced"
+  echo "{BASH_SOURCE[0]} must be executed, not sourced"
   return 1 # shouldn't use exit when sourced
 fi
 
@@ -22,13 +22,13 @@ then
 fi
 
 HEADLESS_SETUP=${HEADLESS_SETUP:-false}
-if [ "$HEADLESS_SETUP" = "false" -a -t 0 ]
+if [ "$HEADLESS_SETUP" = "false" ] && [ -t 0 ]
 then
   # running in terminal in non-headless mode
-  if [ -f /boot/teslausb_setup_variables.conf -o -f /root/teslausb_setup_variables.conf ]
+  if [ -f /boot/teslausb_setup_variables.conf ] || [ -f /root/teslausb_setup_variables.conf ]
   then
     # headless setup variables are available
-    read -p "Read setup info from teslausb_setup_variables.conf (yes/no/cancel)? " answer
+    read -r -p "Read setup info from teslausb_setup_variables.conf (yes/no/cancel)? " answer
     case ${answer:0:1} in
       y|Y )
           HEADLESS_SETUP=true
@@ -58,13 +58,14 @@ export usb_drive=${usb_drive:-''}
 
 function setup_progress () {
   local setup_logfile=/boot/teslausb-headless-setup.log
-  if [ $HEADLESS_SETUP = "true" -a -w $setup_logfile ]
+  if [ $HEADLESS_SETUP = "true" ] && [ -w $setup_logfile ]
   then
-    echo "$( date ) : $@" >> "$setup_logfile"
+    echo "$( date ) : $*" >> "$setup_logfile"
   fi
   echo "$@"
 }
 
+# shellcheck disable=SC2046
 if ! [ $(id -u) = 0 ]
 then
   setup_progress "STOP: Run sudo -i."
@@ -72,7 +73,7 @@ then
 fi
 
 function dehumanize () {
-  echo $(($(echo $1 | sed 's/G/*1024M/;s/M/*1024K/;s/K/*1024/')))
+  echo $(($(echo "$1" | sed 's/G/*1024M/;s/M/*1024K/;s/K/*1024/')))
 }
 
 REBOOT=false
@@ -87,16 +88,16 @@ then
   REBOOT=true
 fi
 
-INCREASE_ROOT_SIZE=$(($(dehumanize $INCREASE_ROOT_SIZE) / 512))
+INCREASE_ROOT_SIZE=$(($(dehumanize "$INCREASE_ROOT_SIZE") / 512))
 
-if [ "$INCREASE_ROOT_SIZE" != "0" -a ! -e /dev/mmcblkp03 ]
+if [ "$INCREASE_ROOT_SIZE" != "0" ] && [ ! -e /dev/mmcblkp03 ]
 then
   if [ ! -e /root/TESLAUSB_ROOT_PARTITION_INCREASED ]
   then
     touch /root/TESLAUSB_ROOT_PARTITION_INCREASED
     ROOTSTART=$(partx --show -g -o START /dev/mmcblk0p2)
     ROOTSIZE=$(partx --show -g -o SECTORS /dev/mmcblk0p2)
-    ROOTSIZE=$(($ROOTSIZE+$INCREASE_ROOT_SIZE))
+    ROOTSIZE=$((ROOTSIZE+INCREASE_ROOT_SIZE))
     echo "$ROOTSTART,$ROOTSIZE" | sfdisk --force /dev/mmcblk0 -N 2
     setup_progress "increased root partition size"
     REBOOT=true
@@ -157,7 +158,7 @@ function headless_setup_mark_setup_success () {
 function headless_setup_progress_flash () {
   if [ $USE_LED_FOR_SETUP_PROGRESS = "true" ] && [ $HEADLESS_SETUP = "true" ]
   then
-    /etc/stage_flash $1 || setup_progress "error calling stage_flash"
+    /etc/stage_flash "$1" || setup_progress "error calling stage_flash"
   fi
 }
 
@@ -185,10 +186,10 @@ function verify_configuration () {
 }
 
 function curlwrapper () {
-  setup_progress "curl $@"
+  setup_progress "curl $*"
   while ! curl --fail "$@"
   do
-    setup_progress "'curl $@' failed, retrying" > /dev/null
+    setup_progress "'curl $*' failed, retrying" > /dev/null
     sleep 3
   done
 }
@@ -205,7 +206,7 @@ function get_script () {
     export CURL_PREFIX=https://raw.githubusercontent.com/"$REPO"/teslausb/"$BRANCH"
   fi
 
-  curlwrapper -o "$local_path/$name" $CURL_PREFIX/"$remote_path"/"$name"
+  curlwrapper -o "$local_path/$name" "$CURL_PREFIX/$remote_path/$name"
   chmod +x "$local_path/$name"
   setup_progress "Downloaded $local_path/$name ..."
 }
@@ -228,12 +229,9 @@ function get_common_scripts () {
   get_script /root/bin release_music_snapshot.sh run
 }
 
-function fix_cmdline_txt_modules_load ()
-{
+function fix_cmdline_txt_modules_load () {
   setup_progress "Fixing the modules-load parameter in /boot/cmdline.txt..."
-  cp /boot/cmdline.txt ~
-  cat ~/cmdline.txt | sed 's/ modules-load=dwc2,g_ether/ modules-load=dwc2/' > /boot/cmdline.txt
-  rm ~/cmdline.txt
+  sed --in-place -e 's/ modules-load=dwc2,g_ether/ modules-load=dwc2/' /boot/cmdline.txt
   setup_progress "Fixed cmdline.txt."
 }
 
@@ -268,15 +266,19 @@ function create_usb_drive_backing_files () {
 }
 
 function configure_hostname () {
-  local old_host_name=$(hostname)
-  local new_host_name="$TESLAUSB_HOSTNAME"
+  local old_host_name
+  local new_host_name
+
+  old_host_name=$(hostname)
+  new_host_name="$TESLAUSB_HOSTNAME"
+
   # Set the specified hostname if it differs from the current name
   if [ "$new_host_name" != "$old_host_name" ]
   then
     setup_progress "Configuring the hostname..."
-    sed -i -e "s/$old_host_name/$new_host_name/g" /etc/hosts
-    sed -i -e "s/$old_host_name/$new_host_name/g" /etc/hostname
-    while ! hostnamectl set-hostname $new_host_name
+    sed --in-place -e "s/$old_host_name/$new_host_name/g" /etc/hosts
+    sed --in-place -e "s/$old_host_name/$new_host_name/g" /etc/hostname
+    while ! hostnamectl set-hostname "$new_host_name"
     do
       setup_progress "hostnamectl failed, retrying"
       sleep 1
@@ -310,7 +312,8 @@ function upgrade_packages () {
 }
 
 function set_timezone () {
-  if [ ! -z ${timezone:+x} ]
+  # shellcheck disable=SC2154
+  if [ -n "${timezone:+x}" ]
   then
     if [ -f "/usr/share/zoneinfo/$timezone" ]
     then
@@ -336,9 +339,10 @@ function set_timezone () {
 
 function cmd_install {
   /root/bin/remountfs_rw
-  get_script /root/bin $(basename $1) $(dirname $1)
+  # shellcheck disable=SC2046
+  get_script /root/bin $(basename "$1") $(dirname "$1")
   setup_progress "$1 installed in /root/bin/"
-  exit
+  return 0
 }
 
 function cmd_selfupdate {
@@ -352,14 +356,19 @@ function cmd_selfupdate {
     setup_progress "$0 updated"
   fi
   setup_progress "other scripts may need to be updated by running $0"
-  exit 0
+  return 0
 }
 
 function cmd_diagnose {
+  local hardware
+  local os
+
+  hardware=$( tr -d '\000' < /sys/firmware/devicetree/base/model )
+  os=$(. /etc/os-release && echo "$PRETTY_NAME")
   {
     echo -e "====== summary ======"
-    echo -e "hardware: $(cat /sys/firmware/devicetree/base/model | tr -d '\000')"
-    echo -e "OS: $(. /etc/os-release && echo $PRETTY_NAME)"
+    echo -e "hardware: $hardware"
+    echo -e "OS: $os"
     if [ -e /root/teslausb_setup_variables.conf ]
     then
       echo "headless setup config in /root"
@@ -404,16 +413,20 @@ function cmd_diagnose {
     then
       echo "cam disk image not in fstab"
     fi
-    LUN0=/sys/devices/platform/soc/??980000.usb/gadget/lun0/file
-    LUN1=/sys/devices/platform/soc/??980000.usb/gadget/lun1/file
-    if [ -e $LUN0 ]
-    then
-      echo "lun0 connected, from file $(cat $LUN0)"
-    fi
-    if [ -e $LUN1 ]
-    then
-      echo "lun1 connected, from file $(cat $LUN1)"
-    fi
+    for LUN0 in /sys/devices/platform/soc/??980000.usb/gadget/lun0/file
+    do
+      if [ -e "$LUN0" ]
+      then
+        echo "lun0 connected, from file $(cat "$LUN0")"
+      fi
+    done
+    for LUN1 in /sys/devices/platform/soc/??980000.usb/gadget/lun1/file
+    do
+      if [ -e "$LUN1" ]
+      then
+        echo "lun1 connected, from file $(cat "$LUN1")"
+      fi
+    done
     if ! blkid -L mutable > /dev/null
     then
       echo "mutable partition does not exist"
@@ -427,7 +440,7 @@ function cmd_diagnose {
       echo "mutable not in fstab"
     fi
 
-    numsnapshots=$(mount | grep snapshot | wc -l)
+    numsnapshots=$( mount | grep --count snapshot )
     echo "$numsnapshots snapshots mounted"
 
     if [ ! -e /boot/TESLAUSB_SETUP_FINISHED ]
@@ -437,9 +450,9 @@ function cmd_diagnose {
 
     echo -e "====== disk / images ======"
     parted -s /dev/mmcblk0 print || true
-    if [ ! -z "$usb_drive" ]
+    if [ -n "$usb_drive" ]
     then
-      parted -s $usb_drive print || true
+      parted -s "$usb_drive" print || true
     fi
     if [ -f /backingfiles/cam_disk.bin ]
     then
@@ -535,14 +548,14 @@ fi
 
 BRANCHNAME="$BRANCH"
 
-if [ ! -z ${1:+x} ]
+if [ -n "${1:+x}" ]
 then
   command=cmd_$1
-  if typeset -f $command > /dev/null
+  if typeset -f "$command" > /dev/null
   then
     shift
     $command "$@"
-    exit 0
+    exit $?
   else
     setup_progress "unknown command: $1"
     exit 1
@@ -627,7 +640,7 @@ then
   fi
 fi
 
-if [ ! -z ${AP_SSID:+x} ]
+if [ -n "${AP_SSID:+x}" ]
 then
   get_script /tmp configure-ap.sh setup/pi
   /tmp/configure-ap.sh

--- a/setup/pi/verify-configuration.sh
+++ b/setup/pi/verify-configuration.sh
@@ -24,6 +24,7 @@ function check_supported_hardware () {
 }
 
 function check_available_space () {
+    # shellcheck disable=SC2154
     if [ -z "$usb_drive" ]
     then
       setup_progress "usb_drive is not set. SD card will be used."
@@ -46,11 +47,15 @@ function check_available_space_sd () {
   # The following assumes that the root and boot partitions are adjacent at the start
   # of the disk, and that all the free space is at the end.
 
-  local totalsize=$(blockdev --getsize64 /dev/mmcblk0)
-  local part1size=$(blockdev --getsize64 /dev/mmcblk0p1)
-  local part2size=$(blockdev --getsize64 /dev/mmcblk0p2)
+  local totalsize
+  local part1size
+  local part2size
+  local available_space
 
-  local available_space=$(($totalsize - $part1size - $part2size))
+  totalsize=$(blockdev --getsize64 /dev/mmcblk0)
+  part1size=$(blockdev --getsize64 /dev/mmcblk0p1)
+  part2size=$(blockdev --getsize64 /dev/mmcblk0p2)
+  available_space=$((totalsize - part1size - part2size))
 
   # Require at least 12 GB of available space.
   if [ "$available_space" -lt  $(( (1<<30) * 12)) ]
@@ -67,8 +72,9 @@ function check_available_space_usb () {
   setup_progress "Verifying that there is sufficient space available on the USB drive ..."
 
   # Verify that the disk has been provided and not a partition
-  local drive_type=$(lsblk -pno TYPE $usb_drive| head -n 1)
-  
+  local drive_type
+  drive_type=$(lsblk -pno TYPE "$usb_drive"| head -n 1)
+
   if [ "$drive_type" != "disk" ]
   then
     setup_progress "STOP: The provided drive seems to be a partition. Please specify path to the disk."
@@ -79,13 +85,19 @@ function check_available_space_usb () {
   # All existing partitions on the drive will be erased if backingfiles are to be created or changed. 
   # EXISTING DATA ON THE USB_DRIVE WILL BE REMOVED. 
 
-  local drive_size=$(blockdev --getsize64 $usb_drive)
+  local drive_size
+  drive_size=$(blockdev --getsize64 "$usb_drive")
 
   # Require at least 16GB drive size. 
   if [ "$drive_size" -lt  $(( (1<<30) * 16)) ]
   then
-    setup_progress "STOP: The USB drive is too small: $(expr $drive_size / 1024 / 1024 / 1024)GB available. Expected at least 16GB"
-    setup_progress "$(parted $usb_drive print)"
+    local size_gb
+    local parted
+    size_gb=$(( "$drive_size" / 1024 / 1024 / 1024 ))
+    parted=$(parted "$usb_drive" print)
+
+    setup_progress "STOP: The USB drive is too small: ${size_gb}GB available. Expected at least 16GB"
+    setup_progress "${parted}"
     exit 1
   fi
 


### PR DESCRIPTION
First - This is not really a pull request. It is a request-for-comments. 

I have been playing with a few different ideas to try and solve the "drive too slow" and also implement the ability to move the recent clips off of the RPi and onto the archive server.

General concept as implemented here:
1. The background snapshot loop now copies the files out of the snapshot into /backingfiles/TeslaCam instead of mounting the snapshot permanently and using a series of soft links. (I have a theory that a large number of shared blocks is part of the cause of the "slow usb drive". No proof other than it seems to help.)
2. All of the archiveclips.sh have a consistent command line interface that supports copy and move semantics. This is tested for CIFS. 
3. All of the I/O operations us a ionice to ensure they are behind the _file-storage_ thread for the car.
4. The main archive thread moves files from the cam-drive-image to the /backingfiles/TeslaCam directory and then moves them to the archive.
    * This is to reduce the time that the car does not see the drives mounted.
4. The snapshot loop can now copy files to the archive (this avoids re-copying a file to the archive on each snapshot). 
5. Update the priority of the file-storage thread to the highest priority using ionice.
6. Have the snapshotloop detect when the car stops writing files.
    * This needs some work as it does not detect when the car stops but recent clips are getting moved away.
7. There is a new option to copy the recent clips.
    * This can take a long time.
    * I think we will also needs to disable the car creating more clips if this has any hope if keeping up.
8. The snapshotloop now waits for after a spike/surge in I/O to the drive (presumably from the _file-storage_ thread) before taking a snapshot.

Things I know need work:
* The snapshot for the music image is not working because the snapshot is mounted read-only. Its an easy fix but low on the list.
* I think the amount of code in archiveloop file is getting out of hand. I separated the two modes into a different set of functions but the code needs more organization (IMO). At this point I am planning to move the functions into "sourceable" files but I am open to other suggestions.
* The rsync and rclone archiveclips scripts needs to be tested.

I have been using a version of this code on my Pi0 and it works. I would appreciate additional testers but please realize it is all a work in progress.

If the general strategy looks reasonable I will try and create a new series of patches that are more easily digested. Again, comments are welcomed.
