### PR TITLE
Don't advertise a default route, we're not a router.

### DIFF
--- a/setup/pi/configure-ap.sh
+++ b/setup/pi/configure-ap.sh
@@ -46,6 +46,8 @@ then
 	bind-interfaces
 	bogus-priv
 	dhcp-range=${NET}.100,${NET}.150,12h
+        # don't configure a default route, we're not a router
+        dhcp-option=3
 	EOF
 
   # configure hostapd

--- a/setup/pi/configure-ap.sh
+++ b/setup/pi/configure-ap.sh
@@ -46,8 +46,8 @@ then
 	bind-interfaces
 	bogus-priv
 	dhcp-range=${NET}.100,${NET}.150,12h
-        # don't configure a default route, we're not a router
-        dhcp-option=3
+	# don't configure a default route, we're not a router
+	dhcp-option=3
 	EOF
 
   # configure hostapd


### PR DESCRIPTION
When we're running as an AP, we need to provide DHCP service so clients can connect to us, but since the Pi is NOT a router and does not forward IP packets, we should advertise only access to the local network.

The motivation for this is that multi-interface device (e.g. a phone with cell and wifi) will be able to access the Samba server via wifi, while not cutting off Internet access to the rest of the phone (by default the phone will try to route all traffic through the Pi which is a mistake).