### PR TITLE
Small change to RClone setup instruction

### DIFF
--- a/doc/SetupRClone.md
+++ b/doc/SetupRClone.md
@@ -14,8 +14,8 @@ The easiest way to setup rclone is to:
 - edit "/root/teslausb_setup_variables.conf" and change the archive method to `rclone`
 - add the RCLONE_DRIVE and RCLONE_PATH variables to the config, according to the values you used when you configured the rclone remote:
   ```
-  export RCLONE_DRIVE="remotename"
-  export RCLONE_PATH="remotepathname"
+  export RCLONE_DRIVE=remotename
+  export RCLONE_PATH=remotepathname
   ```
 - run `/root/bin/setup-teslausb`
 


### PR DESCRIPTION
I had a short struggle while configuring the RClone setup because I was using export values with double quotes around the values.
The instruction implies this is required or possible, but in fact, it only works when you don't use them :).
So, to prevent people from losing time debugging on this, let's remove those quotes from the instruction.