### PR TITLE
enabled=true for notification services

### DIFF
--- a/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
+++ b/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
@@ -96,18 +96,18 @@ export HEADLESS_SETUP=true
 # export TESLAUSB_HOSTNAME=teslausb-Model3
 
 # Uncomment if setting up Pushover push notifications
-# export pushover_enabled=false
+# export pushover_enabled=true
 # export pushover_user_key=user_key
 # export pushover_app_key=app_key
 
 # Uncomment if setting up Gotify push notifications
-# export gotify_enabled=false
+# export gotify_enabled=true
 # export gotify_domain=https://gotify.domain.com
 # export gotify_app_token=put_your_token_here
 # export gotify_priority=5
 
 # Uncomment if setting up IFTTT push notifications
-# export ifttt_enabled=false
+# export ifttt_enabled=true
 # export ifttt_event_name=put_your_event_name_here
 # export ifttt_key=put_your_key_here
 


### PR DESCRIPTION
When people want to enable a notification service, it makes more sense to me that the service is enabled after uncommenting the setting, by the default *_enabled=true, instead of the current *_enabled=false. 
This change also makes it consistent, as the AWS SNS notification setting already has the enabled=true value.