### PR TITLE
Send SNS messages (if configured) on for folder upload when using rclone, allows for triggering lambda to process the files.

### DIFF
--- a/run/rclone_archive/archive-clips.sh
+++ b/run/rclone_archive/archive-clips.sh
@@ -2,15 +2,6 @@
 
 source /root/.teslaCamRcloneConfig
 
-function send_completed_sns () {
-  log "Sending SNS message $1 for completed upload."
-
-  source /root/.teslaCamSNSTopicARN
-
-  # shellcheck disable=SC2154
-  python3 /root/bin/send_sns.py -t "$sns_topic_arn" -s "TeslaCam Upload" -m "$1"
-}
-
 log "Moving clips to rclone archive..."
 
 FILE_COUNT=$(cd "$CAM_MOUNT"/TeslaCam && find . -maxdepth 3 -path './SavedClips/*' -type f -o -path './SentryClips/*' -type f | wc -l)
@@ -27,12 +18,10 @@ do
         rclone --config /root/.config/rclone/rclone.conf move "$clipfolder/$folderbase" "$drive:$path/$clipfolderbase/$folderbase" --create-empty-src-dirs --delete-empty-src-dirs >> "$LOG_FILE" 2>&1 || true
         rmdir "$folder"
         /root/bin/send-push-message "TeslaUSB:" "Uploaded $clipfolderbase/$folderbase" || true
-        [ -r "/root/.teslaCamSNSTopicARN" ] && send_completed_sns "$clipfolderbase/$folderbase"
       fi
     done
   fi
 done
-
 
 FILES_REMAINING=$(cd "$CAM_MOUNT"/TeslaCam && find . -maxdepth 3 -path './SavedClips/*' -type f -o -path './SentryClips/*' -type f | wc -l)
 NUM_FILES_MOVED=$((FILE_COUNT-FILES_REMAINING))

--- a/run/rclone_archive/archive-clips.sh
+++ b/run/rclone_archive/archive-clips.sh
@@ -2,6 +2,16 @@
 
 source /root/.teslaCamRcloneConfig
 
+# If configured, send SNS message on each upload, useful for triggering an aws lambda
+function send_completed_sns () {
+  log "Sending SNS message $1 for completed upload."
+
+  source /root/.teslaCamSNSTopicARN
+
+  # shellcheck disable=SC2154
+  python3 /root/bin/send_sns.py -t "$sns_topic_arn" -s "TeslaCam Upload" -m "$1"
+}
+
 log "Moving clips to rclone archive..."
 
 FILE_COUNT=$(cd "$CAM_MOUNT"/TeslaCam && find . -maxdepth 3 -path './SavedClips/*' -type f -o -path './SentryClips/*' -type f | wc -l)
@@ -18,10 +28,12 @@ do
         rclone --config /root/.config/rclone/rclone.conf move "$clipfolder/$folderbase" "$drive:$path/$clipfolderbase/$folderbase" --create-empty-src-dirs --delete-empty-src-dirs >> "$LOG_FILE" 2>&1 || true
         rmdir "$folder"
         /root/bin/send-push-message "TeslaUSB:" "Uploaded $clipfolderbase/$folderbase" || true
+        [ -r "/root/.teslaCamSNSTopicARN" ] && send_completed_sns "$clipfolderbase/$folderbase"
       fi
     done
   fi
 done
+
 
 FILES_REMAINING=$(cd "$CAM_MOUNT"/TeslaCam && find . -maxdepth 3 -path './SavedClips/*' -type f -o -path './SentryClips/*' -type f | wc -l)
 NUM_FILES_MOVED=$((FILE_COUNT-FILES_REMAINING))

--- a/run/rclone_archive/archive-clips.sh
+++ b/run/rclone_archive/archive-clips.sh
@@ -1,21 +1,38 @@
 #!/bin/bash -eu
 
-log "Moving clips to rclone archive..."
-
 source /root/.teslaCamRcloneConfig
+
+function send_completed_sns () {
+  log "Sending SNS message $1 for completed upload."
+
+  source /root/.teslaCamSNSTopicARN
+
+  # shellcheck disable=SC2154
+  python3 /root/bin/send_sns.py -t "$sns_topic_arn" -s "TeslaCam Upload" -m "$1"
+}
+
+log "Moving clips to rclone archive..."
 
 FILE_COUNT=$(cd "$CAM_MOUNT"/TeslaCam && find . -maxdepth 3 -path './SavedClips/*' -type f -o -path './SentryClips/*' -type f | wc -l)
 
-if [ -d "$CAM_MOUNT"/TeslaCam/SavedClips ]
-then
-  # shellcheck disable=SC2154
-  rclone --config /root/.config/rclone/rclone.conf move "$CAM_MOUNT"/TeslaCam/SavedClips "$drive:$path"/SavedClips/ --create-empty-src-dirs --delete-empty-src-dirs >> "$LOG_FILE" 2>&1 || echo ""
-fi
+for clipfolder in "$CAM_MOUNT"/TeslaCam/SavedClips "$CAM_MOUNT"/TeslaCam/SentryClips
+do
+  if [ -d "$clipfolder" ]; then
+    clipfolderbase="${clipfolder##*/}"
+    for folder in "$clipfolder"/*; do
+      if [ -d "${folder}" ]; then
+        folderbase="${folder##*/}"
+        log "rclone uploading $clipfolderbase/$folderbase"
+        # shellcheck disable=SC2154
+        rclone --config /root/.config/rclone/rclone.conf move "$clipfolder/$folderbase" "$drive:$path/$clipfolderbase/$folderbase" --create-empty-src-dirs --delete-empty-src-dirs >> "$LOG_FILE" 2>&1 || true
+        rmdir "$folder"
+        /root/bin/send-push-message "TeslaUSB:" "Uploaded $clipfolderbase/$folderbase" || true
+        [ -r "/root/.teslaCamSNSTopicARN" ] && send_completed_sns "$clipfolderbase/$folderbase"
+      fi
+    done
+  fi
+done
 
-if [ -d "$CAM_MOUNT"/TeslaCam/SentryClips ]
-then
-  rclone --config /root/.config/rclone/rclone.conf move "$CAM_MOUNT"/TeslaCam/SentryClips "$drive:$path"/SentryClips/ --create-empty-src-dirs --delete-empty-src-dirs >> "$LOG_FILE" 2>&1 || echo ""
-fi
 
 FILES_REMAINING=$(cd "$CAM_MOUNT"/TeslaCam && find . -maxdepth 3 -path './SavedClips/*' -type f -o -path './SentryClips/*' -type f | wc -l)
 NUM_FILES_MOVED=$((FILE_COUNT-FILES_REMAINING))

--- a/run/send_sns.py
+++ b/run/send_sns.py
@@ -1,16 +1,19 @@
 import argparse
 import boto3
 
+
 def send_sns(topic: str, subject: str, message: str):
     sns = boto3.client('sns')
     response = sns.publish(TopicArn=topic, Message=message, Subject=subject)
     return response
 
-if __name__== "__main__":
+
+if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument('-t', '--topic', help='The SNS topic to publish to')
     parser.add_argument('-m', '--message', help='The message to publish')
-    parser.add_argument('-s', '--subject', help='The subject of the message to publish')
+    parser.add_argument('-s', '--subject',
+                        help='The subject of the message to publish')
     args = parser.parse_args()
 
     send_sns(args.topic, args.subject, args.message)

--- a/setup/pi/configure.sh
+++ b/setup/pi/configure.sh
@@ -167,6 +167,7 @@ function install_archive_scripts () {
 
 function install_python_packages () {
   setup_progress "Installing python packages..."
+  apt-get update
   apt-get --assume-yes install python3-pip
   pip3 install boto3
 }


### PR DESCRIPTION
After rclone uploads each folder in SentryClips or SavedClips, if SNS is configured, send a message to the SNS topic, this message can be used to trigger a lambda to take action on the uploaded files.  See https://github.com/jspv/tesla_dashcam_ec2lambda for example.  

Also refactored the script to be a loop across SentryClips and SavedClips rather than repeating the code twice.  

Lastly, added apt-get update in configure.sh.  