### PR TITLE
Generic webhook post

### DIFF
--- a/doc/ConfigureNotificationsForArchive.md
+++ b/doc/ConfigureNotificationsForArchive.md
@@ -73,3 +73,13 @@ You can also choose to send notification through AWS SNS. You can create a free 
     export aws_sns_topic_arn=put_your_sns_topicarn_here
     ```
 
+# Webhook
+Generic Webhook call can be used with Node-Red, [Home-Assistant](https://home-assistant.io), and other self hosted automation systems.
+
+1. Setup webhook url with your provider
+2. Run these commands, substituting your url.
+    ```
+    export webhook_enabled=true
+    export webhook_url=http://domain/path
+    ```
+

--- a/doc/ConfigureNotificationsForArchive.md
+++ b/doc/ConfigureNotificationsForArchive.md
@@ -79,7 +79,7 @@ Generic Webhook call can be used with Node-Red, [Home-Assistant](https://home-as
 1. Setup webhook url with your provider
 2. Run these commands, substituting your url.
     ```
-    export webhook_enabled=true
-    export webhook_url=http://domain/path
+    export WEBHOOK_ENABLED=true
+    export WEBHOOK_URL=http://domain/path
     ```
 

--- a/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
+++ b/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
@@ -119,8 +119,8 @@ export HEADLESS_SETUP=true
 # export aws_sns_topic_arn=put_your_sns_topicarn_here
 
 # Uncomment if setting up Webhook notifications
-# export webhook_enabled=true
-# export webhook_url=http://domain/path
+# export WEBHOOK_ENABLED=true
+# export WEBHOOK_URL=http://domain/path
 
 # tesla_dashcam / Trigger file support.
 # Uncomment any trigger_file_xxxxx below if you'd like to create trigger file(s) in the

--- a/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
+++ b/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
@@ -118,6 +118,10 @@ export HEADLESS_SETUP=true
 # export aws_secret_key=put_your_secretkey_here
 # export aws_sns_topic_arn=put_your_sns_topicarn_here
 
+# Uncomment if setting up Webhook notifications
+# export webhook_enabled=true
+# export webhook_url=http://domain/path
+
 # tesla_dashcam / Trigger file support.
 # Uncomment any trigger_file_xxxxx below if you'd like to create trigger file(s) in the
 # archive directory for the listed clip type after all clips have been transferred for that type.

--- a/run/send-push-message
+++ b/run/send-push-message
@@ -57,12 +57,12 @@ function send_sns () {
 
 function send_webhook () {
   log "Sending Webhook message for moved files."
-  echo "sending webhook"
+  
   source /root/.teslaCamWebhookSettings
 
   # shellcheck disable=SC2154
-  echo curl -X POST \
-    -d '{"value1":"'$TITLE'","value2":"'$MESSAGE'"}' \
+  curl -X POST \
+    -d "{\"value1\":\"${TITLE}\",\"value2\":\"${MESSAGE}\"}" \
     $webhook_url
 }
 

--- a/run/send-push-message
+++ b/run/send-push-message
@@ -57,11 +57,11 @@ function send_sns () {
 
 function send_webhook () {
   log "Sending Webhook message for moved files."
-
+  echo "sending webhook"
   source /root/.teslaCamWebhookSettings
 
   # shellcheck disable=SC2154
-  curl -X POST \
+  echo curl -X POST \
     -d '{"value1":"'$TITLE'","value2":"'$MESSAGE'"}' \
     $webhook_url
 }

--- a/run/send-push-message
+++ b/run/send-push-message
@@ -55,7 +55,19 @@ function send_sns () {
   python3 /root/bin/send_sns.py -t "$sns_topic_arn" -s "$TITLE" -m "$MESSAGE"
 }
 
+function send_webhook () {
+  log "Sending Webhook message for moved files."
+
+  source /root/.teslaCamWebhookSettings
+
+  # shellcheck disable=SC2154
+  curl -X POST \
+    -d '{"value1":"'$TITLE'","value2":"'$MESSAGE'"}' \
+    $webhook_url
+}
+
 [ -r "/root/.teslaCamPushoverCredentials" ] && send_pushover
 [ -r "/root/.teslaCamGotifySettings" ] && send_gotify
 [ -r "/root/.teslaCamIftttSettings" ] && send_ifttt
 [ -r "/root/.teslaCamSNSTopicARN" ] && send_sns
+[ -r "/root/.teslaCamWebhookSettings" ] && send_webhook

--- a/run/send-push-message
+++ b/run/send-push-message
@@ -63,7 +63,7 @@ function send_webhook () {
   # shellcheck disable=SC2154
   curl -X POST \
     -d "{\"value1\":\"${TITLE}\",\"value2\":\"${MESSAGE}\"}" \
-    "$webhook_url"
+    "$WEBHOOK_URL"
 }
 
 [ -r "/root/.teslaCamPushoverCredentials" ] && send_pushover

--- a/run/send-push-message
+++ b/run/send-push-message
@@ -63,7 +63,7 @@ function send_webhook () {
   # shellcheck disable=SC2154
   curl -X POST \
     -d "{\"value1\":\"${TITLE}\",\"value2\":\"${MESSAGE}\"}" \
-    $webhook_url
+    "$webhook_url"
 }
 
 [ -r "/root/.teslaCamPushoverCredentials" ] && send_pushover

--- a/setup/pi/configure.sh
+++ b/setup/pi/configure.sh
@@ -225,6 +225,24 @@ function check_ifttt_configuration () {
     fi
 }
 
+function check_webhook_configuration () {
+    # shellcheck disable=SC2154
+    if [ -n "${webhook_enabled+x}" ]
+    then
+        if [ -z "${webhook_url+x}"  ]
+        then
+            log_progress "STOP: You're trying to setup a Webhook but didn't provide your webhook url."
+            log_progress "Define the variable like this:"
+            log_progress "export webhook_url=http://domain/path/"
+            exit 1
+        elif [ "${webhook_url}" = "http://domain/path/" ]
+        then
+            log_progress "STOP: You're trying to setup a Webhook, but didn't replace the default url."
+            exit 1
+        fi
+    fi
+}
+
 function check_sns_configuration () {
     # shellcheck disable=SC2154
     if [ -n "${sns_enabled+x}" ]
@@ -289,6 +307,19 @@ function configure_ifttt () {
     fi
 }
 
+function configure_webhook () {
+    if [ -n "${webhook_enabled+x}" ]
+    then
+        log_progress "Enabling WEebhook"
+        {
+            echo "export webhook_enabled=true"
+            echo "export webhook_url=$webhook_url"
+        } > /root/.teslaCamWebhookSettings
+    else
+        log_progress "Webhook not configured."
+    fi
+}
+
 function configure_sns () {
     # shellcheck disable=SC2154
     if [ -n "${sns_enabled+x}" ]
@@ -330,6 +361,11 @@ function check_and_configure_ifttt () {
     configure_ifttt
 }
 
+function check_and_configure_webhook () {
+    check_webhook_configuration
+
+    configure_webhook
+}
 
 function check_and_configure_sns () {
     check_sns_configuration

--- a/setup/pi/configure.sh
+++ b/setup/pi/configure.sh
@@ -310,7 +310,7 @@ function configure_ifttt () {
 function configure_webhook () {
     if [ -n "${webhook_enabled+x}" ]
     then
-        log_progress "Enabling WEebhook"
+        log_progress "Enabling Webhook"
         {
             echo "export webhook_enabled=true"
             echo "export webhook_url=$webhook_url"
@@ -390,6 +390,7 @@ mkdir -p /root/bin
 check_and_configure_pushover
 check_and_configure_gotify
 check_and_configure_ifttt
+check_and_configure_webhook
 check_and_configure_sns
 install_push_message_scripts /root/bin
 

--- a/setup/pi/configure.sh
+++ b/setup/pi/configure.sh
@@ -227,15 +227,15 @@ function check_ifttt_configuration () {
 
 function check_webhook_configuration () {
     # shellcheck disable=SC2154
-    if [ -n "${webhook_enabled+x}" ]
+    if [ -n "${WEBHOOK_ENABLED+x}" ]
     then
-        if [ -z "${webhook_url+x}"  ]
+        if [ -z "${WEBHOOK_URL+x}"  ]
         then
             log_progress "STOP: You're trying to setup a Webhook but didn't provide your webhook url."
             log_progress "Define the variable like this:"
-            log_progress "export webhook_url=http://domain/path/"
+            log_progress "export WEBHOOK_URL=http://domain/path/"
             exit 1
-        elif [ "${webhook_url}" = "http://domain/path/" ]
+        elif [ "${WEBHOOK_URL}" = "http://domain/path/" ]
         then
             log_progress "STOP: You're trying to setup a Webhook, but didn't replace the default url."
             exit 1
@@ -308,12 +308,12 @@ function configure_ifttt () {
 }
 
 function configure_webhook () {
-    if [ -n "${webhook_enabled+x}" ]
+    if [ -n "${WEBHOOK_ENABLED+x}" ]
     then
         log_progress "Enabling Webhook"
         {
-            echo "export webhook_enabled=true"
-            echo "export webhook_url=$webhook_url"
+            echo "export WEBHOOK_ENABLED=true"
+            echo "export WEBHOOK_URL=$WEBHOOK_URL"
         } > /root/.teslaCamWebhookSettings
     else
         log_progress "Webhook not configured."


### PR DESCRIPTION
Added a webhook notification method that posts the data as json. 

This should probably have more configuration options but I don't know what those should be. I would suspect that the values submitted might need different names to support something like a slack webhook and probably an authentication header to support other types of webhook services.

Data example:
`{"value1":"TeslaUSB:","value2":"Archiving 1 event folder(s) with 2 file(s) starting at Sun 28 Jun 12:17:41 EDT 2020"}`
`{"value1":"TeslaUSB:","value2":"Moved 2 dashcam file(s), failed to copy 0, deleted 0."}`