### PR TITLE
Add trigger file location at Archive Root

### DIFF
--- a/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
+++ b/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
@@ -126,6 +126,7 @@ export HEADLESS_SETUP=true
 # Uncomment any trigger_file_xxxxx below if you'd like to create trigger file(s) in the
 # archive directory for the listed clip type after all clips have been transferred for that type.
 # eg; export trigger_file_saved=ARCHIVE_UPLOADED would create a file in $ARCHIVE_BASE/SavedClips/ARCHIVE_UPLOADED on your CIFS / Samba server.
+# Uncomment trigger_file_any to create a trigger file in $ARCHIVE_BASE. This will make tesla_dashcam process both SavedClips and SentryClips when either changes.
 # This is useful if using https://github.com/ehendrix23/tesla_dashcam to further process clips.
 # eg; tesla_dashcom --monitor --monitor_trigger $ARCHIVE_BASE/SavedClips/ARCHIVE_UPLOADED $ARCHIVE_BASE/SavedClips
 #
@@ -133,6 +134,7 @@ export HEADLESS_SETUP=true
 #.
 # export trigger_file_saved=ARCHIVE_UPLOADED
 # export trigger_file_sentry=ARCHIVE_UPLOADED
+# export trigger_file_any=ARCHIVE_UPLOADED
 
 # TeslaUSB can optionally use the Tesla API to keep your car awake, so it can
 # power the Pi long enough for the archiving process to complete. To enable

--- a/run/archiveloop
+++ b/run/archiveloop
@@ -328,6 +328,12 @@ function archive_teslacam_clips () {
         export trigger_file_sentry
     fi
 
+    # Create trigger file for Archive root
+    if [ -n "${trigger_file_any+x}" ]
+    then
+        export trigger_file_any
+    fi
+
     /root/bin/archive-clips.sh
 
     # If Sentry Mode was previously disabled, restore it to that state

--- a/run/cifs_archive/archive-clips.sh
+++ b/run/cifs_archive/archive-clips.sh
@@ -100,6 +100,14 @@ then
   touch "$ARCHIVE_MOUNT/SentryClips/${trigger_file_sentry}"
 fi
 
+# Create trigger file for Archive Root
+# shellcheck disable=SC2154
+if [ -n "${trigger_file_any+x}" ]
+then
+  log "Creating Archive Root Trigger File: $ARCHIVE_MOUNT/${trigger_file_any}"
+  touch "$ARCHIVE_MOUNT/${trigger_file_any}"
+fi
+
 # 2020.8.1 firmware adds a folder for track mode V2
 moveclips "$CAM_MOUNT/TeslaTrackMode"
 


### PR DESCRIPTION
When no source is specified with tesla_dashcam, tesla_dashcam uses trigger file path as source. Putting trigger file in the file root allows tesla_dashcam to scan both SavedClips & SentryClips on change to either folder.

See Issue #508 