### PR TITLE
Simplified Telegram code and docs. Use hostname as prefix for messages.

### DIFF
--- a/doc/ConfigureNotificationsForArchive.md
+++ b/doc/ConfigureNotificationsForArchive.md
@@ -84,11 +84,14 @@ Generic Webhook call can be used with Node-Red, [Home-Assistant](https://home-as
     ```
 
 # Telegram
-You can choose to send notifications via [Telegram](https://telegram.org/). This is a free alternative, but you need Telegram app on your device. It is available for iOS as well as Android and other platforms. See the complete list [here](https://telegram.org/apps)
+You can choose to send notifications via [Telegram](https://telegram.org/). This is a completely free alternative, but you need Telegram app (also free) on your device. It is available for iOS as well as Android and other platforms. See the complete list [here](https://telegram.org/apps)
 
-1. Follow the instructions [here](https://www.siteguarding.com/en/how-to-get-telegram-bot-api-token) to get your bot token. 
-2. If the API key does not have the "bot" prefix. Make sure you add it. See example below. 
-3. Run these commands, substituting your url.
+1. If you don't already have it, download the Telegram Client for your device [here](https://telegram.org/apps) and go through the sign up process. 
+2. Once sign-up is complete, you can add [this](https://thereisabotforthat.com/bots/userinfobot) bot to your telegram client. 
+3. Send any message (e.g. "Hi") to the bot and it will respond with your id. This identifies the recipient and is the value you will use for TELEGRAM_CHAT_ID
+4. You will need to create a new bot that acts as a sender. Follow the instructions [here](https://www.siteguarding.com/en/how-to-get-telegram-bot-api-token) to get your bot token. 
+5. If the API key does not have the "bot" prefix. Make sure you include it when entering TELEGRAM_BOT_TOKEN. 
+6. Remove the comments and update the following values in the ```teslausb_setup_variables.conf``` file.
     ```
     export TELEGRAM_ENABLED=true
     export TELEGRAM_CHAT_ID=123456789

--- a/run/archiveloop
+++ b/run/archiveloop
@@ -39,6 +39,12 @@ function log () {
 # when sourced, setup-teslausb sets the config variables in the environment
 source /root/bin/setup-teslausb
 
+# Uses hostname for notification.
+if [ -z "${TESLAUSB_HOSTNAME+x}" ]
+then
+  export TESLAUSB_HOSTNAME=$HOSTNAME
+fi
+
 if [ -z "${ARCHIVE_SERVER+x}" ]
 then
   case "$ARCHIVE_SYSTEM" in
@@ -306,7 +312,7 @@ function archive_teslacam_clips () {
   then
     log "Starting recording archiving: $DIR_COUNT event folder(s) with $FILE_COUNT file(s)"
 
-    /root/bin/send-push-message "TeslaUSB:" "Archiving $DIR_COUNT event folder(s) with $FILE_COUNT file(s) starting at $(date)"
+    /root/bin/send-push-message "$TESLAUSB_HOSTNAME:" "Archiving $DIR_COUNT event folder(s) with $FILE_COUNT file(s) starting at $(date)"
 
     # Ensure Sentry Mode is enabled before archiving
     declare is_sentry_mode_enabled

--- a/run/cifs_archive/archive-clips.sh
+++ b/run/cifs_archive/archive-clips.sh
@@ -120,7 +120,7 @@ log "Moved $NUM_FILES_MOVED file(s), failed to copy $NUM_FILES_FAILED, deleted $
 
 if [ $NUM_FILES_MOVED -gt 0 ]
 then
-  /root/bin/send-push-message "TeslaUSB:" "Moved $NUM_FILES_MOVED dashcam file(s), failed to copy $NUM_FILES_FAILED, deleted $NUM_FILES_DELETED."
+  /root/bin/send-push-message "$TESLAUSB_HOSTNAME:" "Moved $NUM_FILES_MOVED dashcam file(s), failed to copy $NUM_FILES_FAILED, deleted $NUM_FILES_DELETED."
 fi
 
 log "Finished moving clips to archive."

--- a/run/cifs_archive/copy-music.sh
+++ b/run/cifs_archive/copy-music.sh
@@ -105,5 +105,5 @@ log "Copied $NUM_FILES_COPIED music file(s), deleted $NUM_FILES_DELETED, skipped
 
 if [ $NUM_FILES_COPIED -gt 0 ]
 then
-  /root/bin/send-push-message "TeslaUSB:" "Copied $NUM_FILES_COPIED music file(s), deleted $NUM_FILES_DELETED, skipped $NUM_FILES_SKIPPED previously-copied files, encountered $NUM_FILES_ERROR copy errors and $NUM_FILES_DELETE_ERROR delete errors."
+  /root/bin/send-push-message "$TESLAUSB_HOSTNAME:" "Copied $NUM_FILES_COPIED music file(s), deleted $NUM_FILES_DELETED, skipped $NUM_FILES_SKIPPED previously-copied files, encountered $NUM_FILES_ERROR copy errors and $NUM_FILES_DELETE_ERROR delete errors."
 fi

--- a/run/rclone_archive/archive-clips.sh
+++ b/run/rclone_archive/archive-clips.sh
@@ -26,6 +26,6 @@ FILES_REMAINING=$(cd "$CAM_MOUNT" && find . -maxdepth 4 -path './TeslaCam/SavedC
 NUM_FILES_MOVED=$((FILE_COUNT-FILES_REMAINING))
 
 log "Moved $NUM_FILES_MOVED file(s)."
-/root/bin/send-push-message "TeslaUSB:" "Moved $NUM_FILES_MOVED dashcam file(s)."
+/root/bin/send-push-message "$TESLAUSB_HOSTNAME:" "Moved $NUM_FILES_MOVED dashcam file(s)."
 
 log "Finished moving clips to rclone archive"

--- a/run/rsync_archive/archive-clips.sh
+++ b/run/rsync_archive/archive-clips.sh
@@ -11,7 +11,7 @@ if (( num_files_moved > 0 ))
 then
   find "$CAM_MOUNT/Teslacam/SavedClips/" "$CAM_MOUNT/Teslacam/SentryClips/" -depth -type d -empty -exec rmdir "{}" \;
   log "Successfully synced files through rsync."
-  /root/bin/send-push-message "TeslaUSB:" "Moved $num_files_moved dashcam files"
+  /root/bin/send-push-message "$TESLAUSB_HOSTNAME:" "Moved $num_files_moved dashcam files"
 else
   log "No files archived."
 fi

--- a/run/send-push-message
+++ b/run/send-push-message
@@ -58,11 +58,12 @@ function send_sns () {
 function send_telegram () {
   log "Sending Telegram message for moved files."
 
-  source /root/.teslaCamTelegramSettings
-
-  curl -v -H "Content-Type: application/json" -d \
-  '{"chat_id": "'"$TELEGRAM_CHAT_ID"'", "text": "'"$TITLE $MESSAGE"'", "disable_notification": '"$TELEGRAM_SILENT_NOTIFY"' }' \
-  https://api.telegram.org/"$TELEGRAM_BOT_TOKEN"/sendMessage
+  if [ -n "${TELEGRAM_ENABLED+x}" ]
+  then
+    curl -v -H "Content-Type: application/json" -d \
+      '{"chat_id": "'"$TELEGRAM_CHAT_ID"'", "text": "'"$TITLE $MESSAGE"'", "disable_notification": '"$TELEGRAM_SILENT_NOTIFY"' }' \
+      https://api.telegram.org/"$TELEGRAM_BOT_TOKEN"/sendMessage
+  fi
 
   
 }
@@ -83,4 +84,4 @@ function send_webhook () {
 [ -r "/root/.teslaCamIftttSettings" ] && send_ifttt
 [ -r "/root/.teslaCamSNSTopicARN" ] && send_sns
 [ -r "/root/.teslaCamWebhookSettings" ] && send_webhook
-[ -r "/root/.teslaCamTelegramSettings" ] && send_telegram
+send_telegram

--- a/run/send-push-message
+++ b/run/send-push-message
@@ -56,10 +56,9 @@ function send_sns () {
 }
 
 function send_telegram () {
-  log "Sending Telegram message for moved files."
-
   if [ -n "${TELEGRAM_ENABLED+x}" ]
   then
+    log "Sending Telegram message for moved files."
     curl -v -H "Content-Type: application/json" -d \
       '{"chat_id": "'"$TELEGRAM_CHAT_ID"'", "text": "'"$TITLE $MESSAGE"'", "disable_notification": '"$TELEGRAM_SILENT_NOTIFY"' }' \
       https://api.telegram.org/"$TELEGRAM_BOT_TOKEN"/sendMessage

--- a/setup/pi/configure.sh
+++ b/setup/pi/configure.sh
@@ -329,12 +329,6 @@ function configure_telegram () {
     if [ -n "${TELEGRAM_ENABLED+x}" ]
     then
         log_progress "Enabling Telegram"
-        {
-            echo "export TELEGRAM_ENABLED=true"
-            echo "export TELEGRAM_CHAT_ID=$TELEGRAM_CHAT_ID"
-            echo "export TELEGRAM_BOT_TOKEN=$TELEGRAM_BOT_TOKEN"
-            echo "export TELEGRAM_SILENT_NOTIFY=$TELEGRAM_SILENT_NOTIFY"
-        } > /root/.teslaCamTelegramSettings
     else
         log_progress "Telegram not configured."
     fi


### PR DESCRIPTION
1. Added additional instructions for Telegram Setup
2. Cleaned up Telegram code to be simpler. 
3. Added hostname to be the identifier for notifications. Chose hostname because 
      - if people have configured different hostnames, they automatically benefit
      - for users who have not configured hostname, the impact is minimal (change from TeslaUSB to teslausb)
      - no real advantage to adding another variable. 