### PR TITLE
Added Domain Security Option

### DIFF
--- a/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
+++ b/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
@@ -18,6 +18,13 @@ export SHARE_USER=username
 export SHARE_PASSWORD=password
 # export cifs_version="3.0"
 
+
+# Variables for DOMAIN (NETBIOS) sharing setup
+#export DOMAIN_ENABLE=true
+#export SHARE_DOMAIN=<DOMAIN>
+
+
+
 # The following option is only for the Pi4. If you wish to boot the Pi4 from
 # sd card, but store recordings on a USB drive or SSD, uncomment the following
 # line. If you don't plan on using an sd card at all (i.e. you are both booting

--- a/run/cifs_archive/write-archive-configs-to.sh
+++ b/run/cifs_archive/write-archive-configs-to.sh
@@ -2,7 +2,7 @@
 
 FILE_PATH="$1"
 
-if [ -z "$DOMAIN_ENABLE" ]; then
+if [[ "$DOMAIN_ENABLE" = false ]]; then
   (
     echo "username=$SHARE_USER"
     echo "password=$SHARE_PASSWORD"

--- a/run/cifs_archive/write-archive-configs-to.sh
+++ b/run/cifs_archive/write-archive-configs-to.sh
@@ -2,8 +2,15 @@
 
 FILE_PATH="$1"
 
-(
-  echo "username=$SHARE_USER"
-  echo "password=$SHARE_PASSWORD"
-  echo "domain=$SHARE_DOMAIN"
-) > "$FILE_PATH"
+if [ -z "$DOMAIN_ENABLE" ]; then
+  (
+    echo "username=$SHARE_USER"
+    echo "password=$SHARE_PASSWORD"
+  ) > "$FILE_PATH"
+else
+  (
+    echo "username=$SHARE_USER"
+    echo "password=$SHARE_PASSWORD"
+    echo "domain=$SHARE_DOMAIN"
+  ) > "$FILE_PATH"
+fi

--- a/run/cifs_archive/write-archive-configs-to.sh
+++ b/run/cifs_archive/write-archive-configs-to.sh
@@ -5,4 +5,5 @@ FILE_PATH="$1"
 (
   echo "username=$SHARE_USER"
   echo "password=$SHARE_PASSWORD"
+  echo "domain=$SHARE_DOMAIN"
 ) > "$FILE_PATH"

--- a/setup/pi/configure.sh
+++ b/setup/pi/configure.sh
@@ -66,9 +66,7 @@ function check_archive_configs () {
             check_variable "SHARE_NAME"
             check_variable "SHARE_USER"
             check_variable "SHARE_PASSWORD"
-			if [ -z "$DOMAIN_ENABLE" ]; then
-			  echo "Domain Not Enabled"
-			else 
+			if [[ "$DOMAIN_ENABLE" = true ]]; then
 			  check_variable "SHARE_DOMAIN"  
 			fi
             check_variable "ARCHIVE_SERVER"

--- a/setup/pi/configure.sh
+++ b/setup/pi/configure.sh
@@ -66,6 +66,7 @@ function check_archive_configs () {
             check_variable "SHARE_NAME"
             check_variable "SHARE_USER"
             check_variable "SHARE_PASSWORD"
+			check_variable "SHARE_DOMAIN"
             check_variable "ARCHIVE_SERVER"
             ;;
         none)

--- a/setup/pi/configure.sh
+++ b/setup/pi/configure.sh
@@ -66,7 +66,9 @@ function check_archive_configs () {
             check_variable "SHARE_NAME"
             check_variable "SHARE_USER"
             check_variable "SHARE_PASSWORD"
-			check_variable "SHARE_DOMAIN"
+			if [ -n "$DOMAIN_ENABLE" ]; then
+			  check_variable "SHARE_DOMAIN"
+			fi
             check_variable "ARCHIVE_SERVER"
             ;;
         none)

--- a/setup/pi/configure.sh
+++ b/setup/pi/configure.sh
@@ -66,8 +66,10 @@ function check_archive_configs () {
             check_variable "SHARE_NAME"
             check_variable "SHARE_USER"
             check_variable "SHARE_PASSWORD"
-			if [ -n "$DOMAIN_ENABLE" ]; then
-			  check_variable "SHARE_DOMAIN"
+			if [ -z "$DOMAIN_ENABLE" ]; then
+			  echo "Domain Not Enabled"
+			else 
+			  check_variable "SHARE_DOMAIN"  
 			fi
             check_variable "ARCHIVE_SERVER"
             ;;

--- a/setup/pi/setup-teslausb
+++ b/setup/pi/setup-teslausb
@@ -27,6 +27,7 @@ function read_setup_variables {
   newnamefor[shareuser]=SHARE_USER
   newnamefor[sharedomain]=SHARE_DOMAIN
   newnamefor[sharepassword]=SHARE_PASSWORD
+  newnamefor[domainenable]=DOMAIN_ENABLE
   newnamefor[tesla_email]=TESLA_EMAIL
   newnamefor[tesla_password]=TESLA_PASSWORD
   newnamefor[tesla_vin]=TESLA_VIN

--- a/setup/pi/setup-teslausb
+++ b/setup/pi/setup-teslausb
@@ -58,7 +58,7 @@ function read_setup_variables {
   export CAM_SIZE=${CAM_SIZE:-90%}
   export MUSIC_SIZE=${MUSIC_SIZE:-0}
   export USB_DRIVE=${USB_DRIVE:-''}
-  DOMAIN_ENABLE=${DOMAIN_ENABLE:-false}
+  export DOMAIN_ENABLE=${DOMAIN_ENABLE:-false}
 }
 
 if [ "$0" = "-bash" ]

--- a/setup/pi/setup-teslausb
+++ b/setup/pi/setup-teslausb
@@ -27,7 +27,6 @@ function read_setup_variables {
   newnamefor[shareuser]=SHARE_USER
   newnamefor[sharedomain]=SHARE_DOMAIN
   newnamefor[sharepassword]=SHARE_PASSWORD
-  newnamefor[domainenable]=DOMAIN_ENABLE
   newnamefor[tesla_email]=TESLA_EMAIL
   newnamefor[tesla_password]=TESLA_PASSWORD
   newnamefor[tesla_vin]=TESLA_VIN

--- a/setup/pi/setup-teslausb
+++ b/setup/pi/setup-teslausb
@@ -25,6 +25,7 @@ function read_setup_variables {
   newnamefor[musicsize]=MUSIC_SIZE
   newnamefor[sharename]=SHARE_NAME
   newnamefor[shareuser]=SHARE_USER
+  newnamefor[sharedomain]=SHARE_DOMAIN
   newnamefor[sharepassword]=SHARE_PASSWORD
   newnamefor[tesla_email]=TESLA_EMAIL
   newnamefor[tesla_password]=TESLA_PASSWORD

--- a/setup/pi/setup-teslausb
+++ b/setup/pi/setup-teslausb
@@ -58,6 +58,7 @@ function read_setup_variables {
   export CAM_SIZE=${CAM_SIZE:-90%}
   export MUSIC_SIZE=${MUSIC_SIZE:-0}
   export USB_DRIVE=${USB_DRIVE:-''}
+  DOMAIN_ENABLE=${DOMAIN_ENABLE:-false}
 }
 
 if [ "$0" = "-bash" ]


### PR DESCRIPTION
Hi,

These changes allow one to use a domain security, not just windows security.  Some power home users might find this useful.

Simple changes, adds a new variable to be added to the CIFS login credentials, and a check on whether to use this or not using IF statements, setting default as false.

Thanks,