### PR TITLE
Add SHARE_DOMAIN parameter for CIFS.

### DIFF
--- a/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
+++ b/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
@@ -16,6 +16,7 @@ export ARCHIVE_SERVER=your_archive_name_or_ip
 export SHARE_NAME=your_archive_share_name
 export SHARE_USER=username
 export SHARE_PASSWORD=password
+# export SHARE_DOMAIN=domain
 # export cifs_version="3.0"
 
 # The following option is only for the Pi4. If you wish to boot the Pi4 from

--- a/run/cifs_archive/write-archive-configs-to.sh
+++ b/run/cifs_archive/write-archive-configs-to.sh
@@ -5,7 +5,7 @@ FILE_PATH="$1"
 (
   echo "username=$SHARE_USER"
   echo "password=$SHARE_PASSWORD"
-  if [ -n "$SHARE_DOMAIN" ]
+  if [ -n "${SHARE_DOMAIN+x}" ]
   then
     echo "domain=$SHARE_DOMAIN"
   fi

--- a/run/cifs_archive/write-archive-configs-to.sh
+++ b/run/cifs_archive/write-archive-configs-to.sh
@@ -5,4 +5,8 @@ FILE_PATH="$1"
 (
   echo "username=$SHARE_USER"
   echo "password=$SHARE_PASSWORD"
+  if [ -n "$SHARE_DOMAIN" ]
+  then
+    echo "domain=$SHARE_DOMAIN"
+  fi
 ) > "$FILE_PATH"


### PR DESCRIPTION
Allows to set the domain parameter for CIFS shares via SHARE_DOMAIN.