### PR TITLE
Added sleep after initial fsck to prevent usb mount behavior prior to networking

### DIFF
--- a/run/archiveloop
+++ b/run/archiveloop
@@ -554,6 +554,8 @@ fi
 
 mount_and_fix_errors_in_files
 
+sleep 20
+
 if archive_is_reachable
 then
   fastblink


### PR DESCRIPTION
Noticed that on initial boot the teslausb main archiveloop would present the mass storage CAM drive to the Tesla as networking was still settling and connecting (disconnected state) (probably systemd doing a parallel boot).  Once networking was up it would disconnect the mass storage device, run the fsck program again, and reconnect the mass storage device.  This prevents that behavior by giving networking more time to settle and connect if it is in range of it's SSID.