### PR TITLE
Always regenerate fstab entries from setup

### DIFF
--- a/run/cifs_archive/verify-and-configure-archive.sh
+++ b/run/cifs_archive/verify-and-configure-archive.sh
@@ -120,11 +120,9 @@ function configure_archive () {
   local credentials_file_path="/root/.teslaCamArchiveCredentials"
   /tmp/write-archive-configs-to.sh "$credentials_file_path"
 
-  if ! grep -w -q "$archive_path" /etc/fstab
-  then
-    local sharenameforstab="${SHARE_NAME// /\\040}"
-    echo "//$ARCHIVE_SERVER/$sharenameforstab $archive_path cifs noauto,credentials=${credentials_file_path},iocharset=utf8,file_mode=0777,dir_mode=0777,$VERS_OPT,$SEC_OPT 0" >> /etc/fstab
-  fi
+  sed -i "/$archive_path/ d" /etc/fstab
+  local sharenameforstab="${SHARE_NAME// /\\040}"
+  echo "//$ARCHIVE_SERVER/$sharenameforstab $archive_path cifs noauto,credentials=${credentials_file_path},iocharset=utf8,file_mode=0777,dir_mode=0777,$VERS_OPT,$SEC_OPT 0" >> /etc/fstab
 
   if [ -n "${musicsharename:+x}" ]
   then
@@ -132,11 +130,9 @@ function configure_archive () {
     then
       mkdir "$music_archive_path"
     fi
-    if ! grep -w -q "$music_archive_path" /etc/fstab
-    then
-      local musicsharenameforstab="${musicsharename// /\\040}"
-      echo "//$ARCHIVE_SERVER/$musicsharenameforstab $music_archive_path cifs noauto,credentials=${credentials_file_path},iocharset=utf8,file_mode=0777,dir_mode=0777,$VERS_OPT,$SEC_OPT 0" >> /etc/fstab
-    fi
+    sed -i "/$music_archive_path/ d" /etc/fstab
+    local musicsharenameforstab="${musicsharename// /\\040}"
+    echo "//$ARCHIVE_SERVER/$musicsharenameforstab $music_archive_path cifs noauto,credentials=${credentials_file_path},iocharset=utf8,file_mode=0777,dir_mode=0777,$VERS_OPT,$SEC_OPT 0" >> /etc/fstab
   fi
 
   # update fstab if it doesn't already use "noauto" for the archive(s)

--- a/run/cifs_archive/verify-and-configure-archive.sh
+++ b/run/cifs_archive/verify-and-configure-archive.sh
@@ -133,13 +133,6 @@ function configure_archive () {
     local musicsharenameforstab="${musicsharename// /\\040}"
     echo "//$ARCHIVE_SERVER/$musicsharenameforstab $music_archive_path cifs noauto,credentials=${credentials_file_path},iocharset=utf8,file_mode=0777,dir_mode=0777,$VERS_OPT,$SEC_OPT 0" >> /etc/fstab
   fi
-
-  # update fstab if it doesn't already use "noauto" for the archive(s)
-  if grep " credentials=" /etc/fstab
-  then
-    log_progress "adding 'noauto' to archive entries in fstab"
-    sed -i 's/ credentials=/ noauto,credentials=/' /etc/fstab
-  fi
   log_progress "Configured the archive."
 }
 

--- a/run/cifs_archive/verify-and-configure-archive.sh
+++ b/run/cifs_archive/verify-and-configure-archive.sh
@@ -120,7 +120,7 @@ function configure_archive () {
   local credentials_file_path="/root/.teslaCamArchiveCredentials"
   /tmp/write-archive-configs-to.sh "$credentials_file_path"
 
-  sed -i "/$archive_path/ d" /etc/fstab
+  sed -i "/^.*\.teslaCamArchiveCredentials.*$/ d" /etc/fstab
   local sharenameforstab="${SHARE_NAME// /\\040}"
   echo "//$ARCHIVE_SERVER/$sharenameforstab $archive_path cifs noauto,credentials=${credentials_file_path},iocharset=utf8,file_mode=0777,dir_mode=0777,$VERS_OPT,$SEC_OPT 0" >> /etc/fstab
 
@@ -130,7 +130,6 @@ function configure_archive () {
     then
       mkdir "$music_archive_path"
     fi
-    sed -i "/$music_archive_path/ d" /etc/fstab
     local musicsharenameforstab="${musicsharename// /\\040}"
     echo "//$ARCHIVE_SERVER/$musicsharenameforstab $music_archive_path cifs noauto,credentials=${credentials_file_path},iocharset=utf8,file_mode=0777,dir_mode=0777,$VERS_OPT,$SEC_OPT 0" >> /etc/fstab
   fi


### PR DESCRIPTION
This *should* work based on unit tests, but full disclosure:  I haven't done an end-to-end re-setup to be sure.  Fixes #585.