### PR TITLE
Disable SSH compression for rsync clip archive

### DIFF
--- a/run/rsync_archive/archive-clips.sh
+++ b/run/rsync_archive/archive-clips.sh
@@ -5,6 +5,6 @@ source /root/.teslaCamRsyncConfig
 while [ -n "${1+x}" ]
 do
   # shellcheck disable=SC2154
-  rsync -auvhR --timeout=60 --remove-source-files --no-perms --stats --log-file=/tmp/archive-rsync-cmd.log --files-from="$2" "$1" "$user@$server:$path" &> /tmp/rsynclog
+  rsync -e "ssh -o Compression=no" -auvhR --timeout=60 --remove-source-files --no-perms --stats --log-file=/tmp/archive-rsync-cmd.log --files-from="$2" "$1" "$user@$server:$path" &> /tmp/rsynclog
   shift 2
 done


### PR DESCRIPTION
Pi Zero W is limited by CPU when doing clip backup. Disabling SSH compression lets me increase transfer rate from ~15Mbps to ~18Mbps. Not a lot but every bit helps.


```
top - 20:27:54 up 7 min,  1 user,  load average: 3.65, 2.95, 1.49
Tasks:  96 total,   4 running,  92 sleeping,   0 stopped,   0 zombie
%Cpu0  : 22.7 us, 38.6 sy,  0.0 ni,  1.2 id,  0.0 wa,  0.0 hi, 37.4 si,  0.0 st
MiB Mem :    431.9 total,     84.1 free,     38.4 used,    309.3 buff/cache
MiB Swap:      0.0 total,      0.0 free,      0.0 used.    338.1 avail Mem

  PID USER      PR  NI    VIRT    RES    SHR S  %CPU  %MEM     TIME+ COMMAND
  759 root      20   0   15704   8572   4728 R  26.4   1.9   1:43.95 ssh
  800 root      20   0       0      0      0 R  19.3   0.0   0:08.78 kworker/u2:3+brcmf_wq/mmc1:0001:1
   46 root      20   0       0      0      0 I  18.0   0.0   0:11.47 kworker/0:3-events
    5 root      20   0       0      0      0 I  12.7   0.0   1:00.47 kworker/u2:0-brcmf_wq/mmc1:0001:1
  758 root      20   0    8028   2520   1972 R   7.5   0.6   0:29.22 rsync
  797 root      20   0       0      0      0 D   6.2   0.0   0:19.33 kworker/0:1+events
    7 root      20   0       0      0      0 S   4.3   0.0   0:20.02 ksoftirqd/0
  726 root       0 -20       0      0      0 S   1.6   0.0   0:06.86 loop0
```