### PR TITLE
Add Content-Type Header to Webhook.

### DIFF
--- a/run/send-push-message
+++ b/run/send-push-message
@@ -69,6 +69,7 @@ function send_webhook () {
   # shellcheck disable=SC2154
   curl -X POST \
     -d "{\"value1\":\"${TITLE}\",\"value2\":\"${MESSAGE}\"}" \
+    -H "Content-Type: application/json" \
     "$WEBHOOK_URL"
 }
 


### PR DESCRIPTION
When making the call for the webhook, include the content type header.