### PR TITLE
Add support for push messages via Matrix (https://matrix.org)

### DIFF
--- a/doc/ConfigureNotificationsForArchive.md
+++ b/doc/ConfigureNotificationsForArchive.md
@@ -102,7 +102,7 @@ You can choose to send notifications via [Telegram](https://telegram.org/). This
 # Matrix
 Matrix is a federated messaging protocol that can be used via [Matrix.org](https://matrix.org) or self hosted homeservers. Matrix can be used via a web browser or one of the [many available clients](https://matrix.org/clients/).
 
-1. Create an account for your bot on either on [matrix.org](https://matrix.org) or your own homeserver
+1. Create an account for your bot either on [matrix.org](https://matrix.org) or your own homeserver
 2. Create a room where you want to send the notifications to, either as the bot user or invite and join the bot user to the room
 3. Navigate to the room settings to discover the "Internal room ID"
 4. Remove the comments and update the following values in the ```teslausb_setup_variables.conf``` file with the gathered information. Use of `'` is required for MATRIX_PASSWORD and MATRIX_ROOM:

--- a/doc/ConfigureNotificationsForArchive.md
+++ b/doc/ConfigureNotificationsForArchive.md
@@ -98,3 +98,19 @@ You can choose to send notifications via [Telegram](https://telegram.org/). This
     export TELEGRAM_BOT_TOKEN=bot123456789:abcdefghijklmnopqrstuvqxyz987654321
     export TELEGRAM_SILENT_NOTIFY=false
     ```
+
+# Matrix
+Matrix is a federated messaging protocol that can be used via [Matrix.org](https://matrix.org) or self hosted homeservers. Matrix can be used via a web browser or one of the [many available clients](https://matrix.org/clients/).
+
+1. Create an account for your bot on either on [matrix.org](https://matrix.org) or your own homeserver
+2. Create a room where you want to send the notifications to, either as the bot user or invite and join the bot user to the room
+3. Navigate to the room settings to discover the "Internal room ID"
+4. Remove the comments and update the following values in the ```teslausb_setup_variables.conf``` file with the gathered information. Use of `'` is required for MATRIX_PASSWORD and MATRIX_ROOM:
+
+    ```
+    export MATRIX_ENABLED=true
+    export MATRIX_SERVER_URL=https://matrix.org/
+    export MATRIX_USERNAME=put_your_matrix_username_here
+    export MATRIX_PASSWORD='put_your_matrix_password_here'
+    export MATRIX_ROOM='put_the_matrix_target_room_id_here'
+    ```

--- a/doc/ConfigureNotificationsForArchive.md
+++ b/doc/ConfigureNotificationsForArchive.md
@@ -109,7 +109,7 @@ Matrix is a federated messaging protocol that can be used via [Matrix.org](https
 
     ```
     export MATRIX_ENABLED=true
-    export MATRIX_SERVER_URL=https://matrix.org/
+    export MATRIX_SERVER_URL=https://matrix.org
     export MATRIX_USERNAME=put_your_matrix_username_here
     export MATRIX_PASSWORD='put_your_matrix_password_here'
     export MATRIX_ROOM='put_the_matrix_target_room_id_here'

--- a/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
+++ b/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
@@ -128,6 +128,13 @@ export WIFIPASS='your_pass'
 # export WEBHOOK_ENABLED=true
 # export WEBHOOK_URL=http://domain/path
 
+# Uncomment if setting up Matrix notifications
+# export MATRIX_ENABLED=true
+# export MATRIX_SERVER_URL=https://matrix.org/
+# export MATRIX_USERNAME=put_your_matrix_username_here
+# export MATRIX_PASSWORD='put_your_matrix_password_here'
+# export MATRIX_ROOM='put_the_matrix_target_room_id_here'
+
 # tesla_dashcam / Trigger file support.
 # Uncomment any TRIGGER_FILE_xxxxx below to create trigger file(s) in the
 # archive directory for the listed clip type after all clips have been

--- a/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
+++ b/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
@@ -130,7 +130,7 @@ export WIFIPASS='your_pass'
 
 # Uncomment if setting up Matrix notifications
 # export MATRIX_ENABLED=true
-# export MATRIX_SERVER_URL=https://matrix.org/
+# export MATRIX_SERVER_URL=https://matrix.org
 # export MATRIX_USERNAME=put_your_matrix_username_here
 # export MATRIX_PASSWORD='put_your_matrix_password_here'
 # export MATRIX_ROOM='put_the_matrix_target_room_id_here'

--- a/run/send-push-message
+++ b/run/send-push-message
@@ -45,7 +45,7 @@ function send_matrix() {
       export HOME=/root
   fi
 
-  python3 /root/bin/matrixcli send -r "$MATRIX_ROOM" "$message"
+  python3 /root/bin/send_matrix.py "$MATRIX_SERVER_URL" "$MATRIX_USERNAME" "$MATRIX_PASSWORD" "$MATRIX_ROOM" "$message"
 }
 
 function send_telegram () {

--- a/run/send-push-message
+++ b/run/send-push-message
@@ -40,11 +40,6 @@ function send_sns () {
 function send_matrix() {
   log "Send Matrix message."
 
-  if [ -z ${HOME+x} ]
-  then
-      export HOME=/root
-  fi
-
   python3 /root/bin/send_matrix.py "$MATRIX_SERVER_URL" "$MATRIX_USERNAME" "$MATRIX_PASSWORD" "$MATRIX_ROOM" "$message"
 }
 

--- a/run/send-push-message
+++ b/run/send-push-message
@@ -37,6 +37,17 @@ function send_sns () {
   python3 /root/bin/send_sns.py -t "$AWS_SNS_TOPIC_ARN" -s "$title" -m "$message"
 }
 
+function send_matrix() {
+  log "Send Matrix message."
+
+  if [ -z ${HOME+x} ]
+  then
+      export HOME=/root
+  fi
+
+  python3 /root/bin/matrixcli send -r "$MATRIX_ROOM" "$message"
+}
+
 function send_telegram () {
   log "Sending Telegram message."
   curl -v -H "Content-Type: application/json" -d \
@@ -61,5 +72,6 @@ log "$message"
 [ "${SNS_ENABLED:-false}" = "true" ] && send_sns
 [ "${WEBHOOK_ENABLED:-false}" = "true" ] && send_webhook
 [ "${TELEGRAM_ENABLED:-false}" = "true" ] && send_telegram
+[ "${MATRIX_ENABLED:-false}" = "true" ] && send_matrix
 
 exit 0

--- a/run/send_matrix.py
+++ b/run/send_matrix.py
@@ -11,6 +11,15 @@ if len(sys.argv) != 6:
 
 (homeserver, username, password, room_id, message) = sys.argv[1:6]
 
+if homeserver.endswith('/'):
+    homeserver = homeserver[:-1]
+
+if username.startswith('@'):
+    username = username[1:]
+
+if username.find(':') > 0:
+    username = username.split(':')[0]
+
 matrix = None
 
 for retry in range(0, 4):

--- a/run/send_matrix.py
+++ b/run/send_matrix.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+import sys
+import time
+from matrix_client.errors import MatrixHttpLibError
+from matrix_client.client import MatrixClient
+from matrix_client.api import MatrixHttpApi
+
+if len(sys.argv) != 6:
+    sys.stderr.write('usage: %s HOMESERVER_URL USERNAME PASSWORD ROOM_ID MESSAGE_TEXT\n' % sys.argv[0])
+    sys.exit(-1)
+
+(homeserver, username, password, room_id, message) = sys.argv[1:6]
+
+matrix = None
+
+for retry in range(0, 4):
+    try:
+        client = MatrixClient(homeserver)
+        token = client.login(username, password)
+        matrix = MatrixHttpApi(homeserver, token)
+        break
+    except MatrixHttpLibError:
+        sys.stderr.write('Connection failed, retrying...\n')
+        time.sleep(0.25)
+
+if matrix == None:
+    sys.stderr.write('Could not connect to homeserver. Message not sent.\n')
+    sys.exit(-2)
+
+try:
+    client.rooms[room_id].send_text(message)
+except:
+    sys.stderr.write('Failed to send message to room.\n')
+    sys.exit(-3)

--- a/setup/pi/configure.sh
+++ b/setup/pi/configure.sh
@@ -258,7 +258,7 @@ function check_matrix_configuration () {
       then
           log_progress "STOP: You're trying to setup Matrix but didn't provide your server URL, username, password or room."
           log_progress "Define the variable like this:"
-          log_progress "export MATRIX_SERVER_URL=https://matrix.org/"
+          log_progress "export MATRIX_SERVER_URL=https://matrix.org"
           log_progress "export MATRIX_USERNAME=put_your_matrix_username_here"
           log_progress "export MATRIX_PASSWORD='put_your_matrix_password_here'"
           log_progress "export MATRIX_ROOM='put_the_matrix_target_room_id_here'"

--- a/setup/pi/configure.sh
+++ b/setup/pi/configure.sh
@@ -176,10 +176,7 @@ function install_sns_packages () {
 function install_matrix_packages () {
   install_python3_pip
   setup_progress "Installing matrix python packages..."
-  apt-get --assume-yes install python3-gi
   pip3 install matrix_client
-  # matrixcli is currently not available via pip
-  curlwrapper -o /root/bin/matrixcli https://raw.githubusercontent.com/saadrushd/matrixcli/23f29933746c38442a5b0f0d94520b5f544a90a4/matrixcli
 }
 
 function check_pushover_configuration () {
@@ -372,14 +369,6 @@ function configure_matrix () {
   if [ "${MATRIX_ENABLED:-false}" = "true" ]
   then
     log_progress "Enabling Matrix"
-    mkdir -p /root/.config/matrixcli/
-    {
-      echo "def password_eval():"
-      echo "    return '$MATRIX_PASSWORD'"
-      echo ""
-      echo "accounts=[{'server': '$MATRIX_SERVER_URL', 'username': '$MATRIX_USERNAME', 'passeval': password_eval}]"
-    } > /root/.config/matrixcli/config.py
-
     install_matrix_packages
   else
     log_progress "Matrix not configured."
@@ -452,6 +441,7 @@ function install_push_message_scripts() {
   local install_path="$1"
   get_script "$install_path" send-push-message run
   get_script "$install_path" send_sns.py run
+  get_script "$install_path" send_matrix.py run
 }
 
 if [[ $EUID -ne 0 ]]

--- a/setup/pi/configure.sh
+++ b/setup/pi/configure.sh
@@ -369,9 +369,6 @@ function configure_webhook () {
 }
 
 function configure_matrix () {
-  # remove legacy file
-  rm -f /root/.teslaCamMatrixSettings
-
   if [ "${MATRIX_ENABLED:-false}" = "true" ]
   then
     log_progress "Enabling Matrix"


### PR DESCRIPTION
Includes a tiny python script to send push messages to Matrix homeservers via the matrix-python-sdk. The SDK itself is installed via pip.