### PR TITLE
Rclone sync, compare by checksum

### DIFF
--- a/doc/SetupRClone.md
+++ b/doc/SetupRClone.md
@@ -15,11 +15,13 @@ The easiest way to to configure teslausb for rclone is:
 - install rclone: `curl https://rclone.org/install.sh | sudo bash`
 - configure rclone for your chosen storage service: `rclone config`, then follow the instructions from [rclone.org](https://rclone.org/)
 - edit "/root/teslausb_setup_variables.conf" and change the archive method to `rclone`
-- add the RCLONE_DRIVE and RCLONE_PATH variables to the config, according to the values you used when you configured the rclone remote.  
+- add the RCLONE_DRIVE and RCLONE_PATH variables to the config, according to the values you used when you configured the rclone remote.
   RCLONE_DRIVE should be a name shown by `rclone listremotes`, and RCLONE_PATH should be a path that exists on the named remote, i.e. `rclone ls "$RCLONE_DRIVE:$RCLONE_PATH"` should not print an error (but it may print nothing, if the path is newly created and currently empty).
+- optionally add RCLONE_FLAGS with optional flags to add to the command.
   ```
   export RCLONE_DRIVE="remotename"
   export RCLONE_PATH="remotepathname"
+  export RCLONE_FLAGS=""
   ```
 - run `/root/bin/setup-teslausb`
 

--- a/doc/SetupRClone.md
+++ b/doc/SetupRClone.md
@@ -17,11 +17,11 @@ The easiest way to to configure teslausb for rclone is:
 - edit "/root/teslausb_setup_variables.conf" and change the archive method to `rclone`
 - add the RCLONE_DRIVE and RCLONE_PATH variables to the config, according to the values you used when you configured the rclone remote.
   RCLONE_DRIVE should be a name shown by `rclone listremotes`, and RCLONE_PATH should be a path that exists on the named remote, i.e. `rclone ls "$RCLONE_DRIVE:$RCLONE_PATH"` should not print an error (but it may print nothing, if the path is newly created and currently empty).
-- optionally add RCLONE_FLAGS with optional flags to add to the command.
+- optionally populate RCLONE_FLAGS with flags to add to the command, i.e. RCLONE_FLAGS=(--checksum). To specify multiple flags: RCLONE_FLAGS=(--flag1 --flag2)
   ```
   export RCLONE_DRIVE="remotename"
   export RCLONE_PATH="remotepathname"
-  export RCLONE_FLAGS=""
+  export RCLONE_FLAGS=()
   ```
 - run `/root/bin/setup-teslausb`
 

--- a/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
+++ b/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
@@ -21,6 +21,11 @@ export SHARE_PASSWORD=password
 # export CIFS_VERSION="3.0"
 # export CIFS_SEC="ntlm"
 
+# Variables for RClone, used with ARCHIVE_SYSTEM=rclone
+#export RCLONE_DRIVE="remotename"
+#export RCLONE_PATH="remotepathname"
+#export RCLONE_FLAGS=()
+
 # The following option is only for the Pi4. If you wish to boot the Pi4 from
 # sd card, but store recordings on a USB drive or SSD, uncomment the following
 # line. If you don't plan on using an sd card at all (i.e. you are both booting

--- a/run/rclone_archive/archive-clips.sh
+++ b/run/rclone_archive/archive-clips.sh
@@ -2,6 +2,6 @@
 
 while [ -n "${1+x}" ]
 do
-  rclone --config /root/.config/rclone/rclone.conf move -L -c --transfers=1 --files-from "$2" "$1" "$RCLONE_DRIVE:$RCLONE_PATH" >> "$LOG_FILE" 2>&1
+  rclone --config /root/.config/rclone/rclone.conf move -L $RCLONE_FLAGS --transfers=1 --files-from "$2" "$1" "$RCLONE_DRIVE:$RCLONE_PATH" >> "$LOG_FILE" 2>&1
   shift 2
 done

--- a/run/rclone_archive/archive-clips.sh
+++ b/run/rclone_archive/archive-clips.sh
@@ -2,6 +2,6 @@
 
 while [ -n "${1+x}" ]
 do
-  rclone --config /root/.config/rclone/rclone.conf move -L $RCLONE_FLAGS --transfers=1 --files-from "$2" "$1" "$RCLONE_DRIVE:$RCLONE_PATH" >> "$LOG_FILE" 2>&1
+  rclone --config /root/.config/rclone/rclone.conf move -L "${RCLONE_FLAGS[@]:-}" --transfers=1 --files-from "$2" "$1" "$RCLONE_DRIVE:$RCLONE_PATH" >> "$LOG_FILE" 2>&1
   shift 2
 done

--- a/run/rclone_archive/archive-clips.sh
+++ b/run/rclone_archive/archive-clips.sh
@@ -2,6 +2,6 @@
 
 while [ -n "${1+x}" ]
 do
-  rclone --config /root/.config/rclone/rclone.conf move -L --transfers=1 --files-from "$2" "$1" "$RCLONE_DRIVE:$RCLONE_PATH" >> "$LOG_FILE" 2>&1
+  rclone --config /root/.config/rclone/rclone.conf move -L -c --transfers=1 --files-from "$2" "$1" "$RCLONE_DRIVE:$RCLONE_PATH" >> "$LOG_FILE" 2>&1
   shift 2
 done


### PR DESCRIPTION
In case of retries and partial upload.

I had this problem with my nextcloud where files that had correct size and timestamp, but was not uploaded. Apparently the metadata is written to database first and not removed if the upload fails. Comparing by checksum fixed this it for me.

From rclone manual: "-c, --checksum  :  Skip based on checksum (if available) & size, not mod-time & size"
Thus, if target does not support checksum, the default time and size check will be used.