### PR TITLE
rsync_archive: Use --append-verify to continue interrupted uploads

### DIFF
--- a/run/rsync_archive/archive-clips.sh
+++ b/run/rsync_archive/archive-clips.sh
@@ -3,7 +3,7 @@
 while [ -n "${1+x}" ]
 do
   rsync -avhRL --timeout=60 --remove-source-files --no-perms --omit-dir-times --stats \
-        --log-file=/tmp/archive-rsync-cmd.log --ignore-missing-args \
+        --log-file=/tmp/archive-rsync-cmd.log --ignore-missing-args --append-verify \
         --files-from="$2" "$1" "$RSYNC_USER@$RSYNC_SERVER:$RSYNC_PATH" &> /tmp/rsynclog || [[ "$?" = "24" ]]
   shift 2
 done


### PR DESCRIPTION
Will continue the upload in the middle of a file if it's aborted by a
power off.