### PR TITLE
Replace broken legacy Matrix Client SDK

### DIFF
--- a/setup/pi/configure.sh
+++ b/setup/pi/configure.sh
@@ -232,7 +232,7 @@ function install_sns_packages () {
 function install_matrix_packages () {
   install_python3_pip
   setup_progress "Installing matrix python packages..."
-  pip3 install matrix_client
+  pip3 install matrix-nio
 }
 
 function check_pushover_configuration () {


### PR DESCRIPTION
Latest synapse update broke the legacy Matrix Client SDK used by send_matrix.py:
https://github.com/matrix-org/matrix-python-sdk/pull/321

Even though the fix is merged, PyPI package is unlikely to update soon as the SDK is no longer maintained. This PR updates send_matrix.py to use the "official" successor matrix-nio (https://github.com/poljar/matrix-nio) instead of the legacy SDK.