### PR TITLE
Exfat support added

### DIFF
--- a/pi-gen-sources/00-teslausb-tweaks/00-packages
+++ b/pi-gen-sources/00-teslausb-tweaks/00-packages
@@ -8,3 +8,4 @@ nginx
 fcgiwrap
 libnginx-mod-http-fancyindex
 libfuse-dev
+exfatprogs

--- a/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
+++ b/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
@@ -70,6 +70,13 @@ export SHARE_PASSWORD=password
 export CAM_SIZE=30G
 #export MUSIC_SIZE=4G
 
+# Use ExFAT filesystem instead of FAT32. 
+# 
+# ExFAT is supported by Tesla, and is supposed to be
+# slightly faster than FAT32. The 20210805 prebuilt
+# image already comes with kernel ExFAT support.
+# export USE_EXFAT=true
+
 # If you want to automatically copy music from a CIFS share every time
 # the Pi connects to wifi, set the following variable. The share is
 # assumed to exist on the same server as the archive share. It can

--- a/run/archiveloop
+++ b/run/archiveloop
@@ -85,7 +85,8 @@ function fix_errors_in_image () {
   local image="$1"
   log "Running fsck on $image..."
   loopback=$(losetup --show -f -P "$image")
-  /sbin/fsck "${loopback}p1" -- -a |& timestamp '| ' >> "$LOG_FILE" || echo ""
+  # Use -p repair arg. It works with vfat and exfat.
+  /sbin/fsck "${loopback}p1" -- -p |& timestamp '| ' >> "$LOG_FILE" || echo ""
   losetup -d "$loopback"
   log "Finished fsck on $image."
 }

--- a/run/mount_snapshot.sh
+++ b/run/mount_snapshot.sh
@@ -29,9 +29,10 @@ cp --reflink=always "$SRC" "$SNAP"
 # create loopback and scan the partition table, this will create an additional loop
 # device in addition to the main loop device, e.g. /dev/loop0 and /dev/loop0p1
 
+# Use -p repair arg. It works with vfat and exfat.
 LOOP=$(losetup --show -P -f "$SNAP")
 PARTLOOP=${LOOP}p1
-fsck "$PARTLOOP" -- -a || true
+fsck "$PARTLOOP" -- -p || true
 
 # don't need to mount, because autofs will
 losetup -d "$LOOP"

--- a/setup/pi/create-backingfiles.sh
+++ b/setup/pi/create-backingfiles.sh
@@ -165,7 +165,7 @@ rm -rf "$BACKINGFILES_MOUNTPOINT/snapshots"
 if [ "$USE_EXFAT" = true  ]
 then
   # Check if kernel supports ExFAT 
-  if ! lsmod | grep -q exfat &> /dev/null
+  if ! modprobe -n exfat &> /dev/null
   then
     log_progress "kernel does not support ExFAT FS. Reverting to FAT32."
     USE_EXFAT=false

--- a/setup/pi/create-backingfiles.sh
+++ b/setup/pi/create-backingfiles.sh
@@ -165,7 +165,7 @@ rm -rf "$BACKINGFILES_MOUNTPOINT/snapshots"
 if [ "$USE_EXFAT" = true  ]
 then
   # Check if kernel supports ExFAT 
-  if ! modprobe -n exfat &> /dev/null
+  if ! cat /proc/filesystems | grep -q exfat &> /dev/null
   then
     log_progress "kernel does not support ExFAT FS. Reverting to FAT32."
     USE_EXFAT=false

--- a/setup/pi/create-backingfiles.sh
+++ b/setup/pi/create-backingfiles.sh
@@ -164,11 +164,18 @@ rm -rf "$BACKINGFILES_MOUNTPOINT/snapshots"
 
 if [ "$USE_EXFAT" = true  ]
 then
-  # install exfatprogs if needed
-  if ! hash mkfs.exfat &> /dev/null
+  # Check if kernel supports ExFAT 
+  if ! lsmod | grep -q exfat &> /dev/null
   then
-    /root/bin/remountfs_rw
-    apt install -y exfatprogs
+    log_progress "kernel does not support ExFAT FS. Reverting to FAT32."
+    USE_EXFAT=false
+  else
+    # install exfatprogs if needed
+    if ! hash mkfs.exfat &> /dev/null
+    then
+      /root/bin/remountfs_rw
+      apt install -y exfatprogs
+    fi
   fi
 fi
 

--- a/setup/pi/create-backingfiles.sh
+++ b/setup/pi/create-backingfiles.sh
@@ -165,7 +165,7 @@ rm -rf "$BACKINGFILES_MOUNTPOINT/snapshots"
 if [ "$USE_EXFAT" = true  ]
 then
   # Check if kernel supports ExFAT 
-  if ! cat /proc/filesystems | grep -q exfat &> /dev/null
+  if ! grep -q exfat /proc/filesystems &> /dev/null
   then
     log_progress "kernel does not support ExFAT FS. Reverting to FAT32."
     USE_EXFAT=false

--- a/setup/pi/create-backingfiles.sh
+++ b/setup/pi/create-backingfiles.sh
@@ -15,8 +15,9 @@ CAM_SIZE="$1"
 MUSIC_SIZE="$2"
 # strip trailing slash that shell autocomplete might have added
 BACKINGFILES_MOUNTPOINT="${3/%\//}"
+USE_EXFAT="$4"
 
-log_progress "cam: $CAM_SIZE, music: $MUSIC_SIZE, mountpoint: $BACKINGFILES_MOUNTPOINT"
+log_progress "cam: $CAM_SIZE, music: $MUSIC_SIZE, mountpoint: $BACKINGFILES_MOUNTPOINT, exfat: $USE_EXFAT"
 
 G_MASS_STORAGE_CONF_FILE_NAME=/etc/modprobe.d/g_mass_storage.conf
 
@@ -81,17 +82,28 @@ function add_drive () {
   local label="$2"
   local size="$3"
   local filename="$4"
+  local useexfat="$5"
 
   log_progress "Allocating ${size}K for $filename..."
   fallocate -l "$size"K "$filename"
-  echo "type=c" | sfdisk "$filename" > /dev/null
+  if [ "$useexfat" = true  ]
+  then
+    echo "type=7" | sfdisk "$filename" > /dev/null
+  else
+    echo "type=c" | sfdisk "$filename" > /dev/null
+  fi
 
   local partition_offset
   partition_offset=$(first_partition_offset "$filename")
 
   loopdev=$(losetup -o "$partition_offset" -f --show "$filename")
   log_progress "Creating filesystem with label '$label'"
-  mkfs.vfat "$loopdev" -F 32 -n "$label"
+  if [ "$useexfat" = true  ]
+  then
+    mkfs.exfat "$loopdev" -L "$label"
+  else
+    mkfs.vfat "$loopdev" -F 32 -n "$label"
+  fi
   losetup -d "$loopdev"
 
   local mountpoint=/mnt/"$name"
@@ -101,7 +113,12 @@ function add_drive () {
     mkdir "$mountpoint"
   fi
   sed -i "\@^$filename .*@d" /etc/fstab
-  echo "$filename $mountpoint vfat utf8,noauto,users,umask=000,offset=$partition_offset 0 0" >> /etc/fstab
+  if [ "$useexfat" = true  ]
+  then
+    echo "$filename $mountpoint exfat noauto,users,umask=000,offset=$partition_offset 0 0" >> /etc/fstab
+  else
+    echo "$filename $mountpoint vfat utf8,noauto,users,umask=000,offset=$partition_offset 0 0" >> /etc/fstab
+  fi
   log_progress "updated /etc/fstab for $mountpoint"
 }
 
@@ -145,10 +162,20 @@ rm -f "$CAM_DISK_FILE_NAME"
 rm -f "$MUSIC_DISK_FILE_NAME"
 rm -rf "$BACKINGFILES_MOUNTPOINT/snapshots"
 
+if [ "$USE_EXFAT" = true  ]
+then
+  # install exfatprogs if needed
+  if ! hash mkfs.exfat &> /dev/null
+  then
+    /root/bin/remountfs_rw
+    apt install -y exfatprogs
+  fi
+fi
+
 CAM_DISK_SIZE="$(calc_size "$CAM_SIZE")"
 MUSIC_DISK_SIZE="$(calc_size "$MUSIC_SIZE")"
 
-add_drive "cam" "CAM" "$CAM_DISK_SIZE" "$CAM_DISK_FILE_NAME"
+add_drive "cam" "CAM" "$CAM_DISK_SIZE" "$CAM_DISK_FILE_NAME" "$USE_EXFAT"
 log_progress "created camera backing file"
 
 REMAINING_SPACE="$(available_space)"
@@ -163,7 +190,7 @@ fi
 
 if [ "$REMAINING_SPACE" -ge 1024 ] && [ "$MUSIC_DISK_SIZE" -gt 0 ]
 then
-  add_drive "music" "MUSIC" "$MUSIC_DISK_SIZE" "$MUSIC_DISK_FILE_NAME"
+  add_drive "music" "MUSIC" "$MUSIC_DISK_SIZE" "$MUSIC_DISK_FILE_NAME" "$USE_EXFAT"
   log_progress "created music backing file"
   echo "options g_mass_storage file=$MUSIC_DISK_FILE_NAME,$CAM_DISK_FILE_NAME removable=1,1 ro=0,0 stall=0 iSerialNumber=123456" > "$G_MASS_STORAGE_CONF_FILE_NAME"
 else

--- a/setup/pi/setup-teslausb
+++ b/setup/pi/setup-teslausb
@@ -23,7 +23,7 @@ function read_setup_variables {
   newnamefor[archiveserver]=ARCHIVE_SERVER
   newnamefor[camsize]=CAM_SIZE
   newnamefor[musicsize]=MUSIC_SIZE
-  newnamefor[useexfat]]=USE_EXFAT
+  newnamefor[useexfat]=USE_EXFAT
   newnamefor[sharename]=SHARE_NAME
   newnamefor[musicsharename]=MUSIC_SHARE_NAME
   newnamefor[shareuser]=SHARE_USER

--- a/setup/pi/setup-teslausb
+++ b/setup/pi/setup-teslausb
@@ -23,7 +23,6 @@ function read_setup_variables {
   newnamefor[archiveserver]=ARCHIVE_SERVER
   newnamefor[camsize]=CAM_SIZE
   newnamefor[musicsize]=MUSIC_SIZE
-  newnamefor[useexfat]=USE_EXFAT
   newnamefor[sharename]=SHARE_NAME
   newnamefor[musicsharename]=MUSIC_SHARE_NAME
   newnamefor[shareuser]=SHARE_USER

--- a/setup/pi/setup-teslausb
+++ b/setup/pi/setup-teslausb
@@ -23,6 +23,7 @@ function read_setup_variables {
   newnamefor[archiveserver]=ARCHIVE_SERVER
   newnamefor[camsize]=CAM_SIZE
   newnamefor[musicsize]=MUSIC_SIZE
+  newnamefor[useexfat]]=USE_EXFAT
   newnamefor[sharename]=SHARE_NAME
   newnamefor[musicsharename]=MUSIC_SHARE_NAME
   newnamefor[shareuser]=SHARE_USER
@@ -88,6 +89,7 @@ function read_setup_variables {
   export CAM_SIZE=${CAM_SIZE:-90%}
   export MUSIC_SIZE=${MUSIC_SIZE:-0}
   export USB_DRIVE=${USB_DRIVE:-''}
+  export USE_EXFAT=${USE_EXFAT:-false}
 }
 
 if [ "$0" = "-bash" ]
@@ -331,7 +333,7 @@ function create_usb_drive_backing_files () {
   if [ ! -e $BACKINGFILES_MOUNTPOINT/cam_disk.bin ]
   then
     setup_progress "Creating backing disk files."
-    /tmp/create-backingfiles.sh "$CAM_SIZE" "$MUSIC_SIZE" "$BACKINGFILES_MOUNTPOINT"
+    /tmp/create-backingfiles.sh "$CAM_SIZE" "$MUSIC_SIZE" "$BACKINGFILES_MOUNTPOINT" "$USE_EXFAT"
   else
     # mount cam image and make sure the right directories exist
     umount /mnt/cam > /dev/null || true

--- a/tools/resize-image.sh
+++ b/tools/resize-image.sh
@@ -60,10 +60,11 @@ fi
 # remove device from any attached host
 modprobe -r g_mass_storage
 
-# fsck the image, since we may have just yanked it out from under the host
+# fsck the image, since we may have just yanked it out from under the host.
+# Use -p repair arg. It works with vfat and exfat.
 DEVLOOP=$(losetup --show -P -f "$FILE")
 PARTLOOP=${DEVLOOP}p1
-fsck "$PARTLOOP" -- -a > /dev/null || true
+fsck "$PARTLOOP" -- -p > /dev/null || true
 
 # get size of the image file and the partition within
 CURRENT_PARTITION_SIZE=$(($(partx -o SECTORS -g -n 1 "$FILE") * 512 + 512))


### PR DESCRIPTION
To enable, the USE_EXFAT variable has been added to the configuration file.

Tested on a rpi Zero W. There it is at least as fast as FAT32. Maybe on a rpi4 it may be faster.

It depends on the native exfat support added on the 5.7 kernel, so it needs the 20210815 image.

Let me know of any changes/suggestions.