### PR TITLE
Modified check for Raspberry Pi Zero 2

### DIFF
--- a/setup/pi/verify-configuration.sh
+++ b/setup/pi/verify-configuration.sh
@@ -14,7 +14,7 @@ function check_supported_hardware () {
   then
     return
   fi
-  if grep -q 'Raspberry Pi Zero 2' /sys/firmware/devicetree/base/model
+  if grep -q 'Raspberry Pi 2 Model B Rev 1.1' /sys/firmware/devicetree/base/model
   then
     return
   fi


### PR DESCRIPTION
I noticed on my rpi zero 2, I still receive this message:
```
STOP: unsupported hardware: 'Raspberry Pi 2 Model B Rev 1.1'
(only Pi Zero W and Pi 4 have the necessary hardware to run teslausb)
```

So I have changed the check to accomodate the correct name.