### PR TITLE
725 Invalidate bad access_tokens

### DIFF
--- a/run/tesla_api.py
+++ b/run/tesla_api.py
@@ -113,12 +113,12 @@ def _rest_request(url, method=None, data=None):
         response = requests.post(url, headers=headers, data=data)
     else:
         raise ValueError('Unsupported Request Method: {}'.format(method))
-    if  'invalid bearer token' in response.text:
-        _error("Invalid Access token, removing from cache...")
-        _invalidate_access_token()
     if not response.text:
         _error("Fatal Error: Tesla REST Service failed to return a response, access token may have expired")
         sys.exit(1)
+    if  'invalid bearer token' in response.text:
+        _error("Invalid Access token, removing from cache...")
+        _invalidate_access_token()
     json_response = response.json()
 
     # log full JSON response for debugging


### PR DESCRIPTION
If tesla's servers indicate that the access token provided is not valid, clear it from our cache so that future requests generate a new one and don't try to re-use the bad one.

Should fix #725 