### PR TITLE
make rclone archive-clips re-source config

### DIFF
--- a/run/rclone_archive/archive-clips.sh
+++ b/run/rclone_archive/archive-clips.sh
@@ -1,5 +1,9 @@
 #!/bin/bash -eu
 
+# when sourced, setup-teslausb sets the config variables in the environment
+# repeat it here because arrays, like RCLONE_FLAGS, don't export to subshells/child scripts
+source /root/bin/setup-teslausb
+
 flags=("-L" "--transfers=1")
 if [[ -v RCLONE_FLAGS ]]
 then


### PR DESCRIPTION
arrays aren't exported to child scripts/subshells in bash (no real way to 
put them into the environment), so re-source the config so we have the
variables here

I haven't tested this yet, so I'm marking it WIP.