### PR TITLE
Update documentation for rsync.

### DIFF
--- a/doc/OneStepSetup.md
+++ b/doc/OneStepSetup.md
@@ -6,7 +6,7 @@ This is a streamlined process for setting up the Pi. You'll flash a preconfigure
 
 * Assumes your Pi has access to Wifi, with internet access (during setup). (But all setup methods do currently.) USB networking is still enabled for troubleshooting or manual setup
 * This image will work for either _headless_ (tested) or _manual_ (tested less) setup.
-* Currently not tested with the rsync/rclone methods when using headless setup, however you can specify 'none' as the archive method in the config file, which will configure the pi as a wifi-accessible USB drive, so you can then configure rclone/rsync and rerun the setup-teslausb script.
+* Currently not tested with the rclone method when using headless setup, however you can specify 'none' as the archive method in the config file, which will configure the pi as a wifi-accessible USB drive, so you can then [configure rclone](./SetupRClone.md) or [configure rsync](./SetupRSync.md) and rerun the setup-teslausb script.
 
 ## Configure the SD card before first boot of the Pi
 
@@ -74,6 +74,8 @@ You should see in `/boot` the `TESLAUSB_SETUP_FINISHED` and `WIFI_ENABLED` files
   * If still no go, re-run `/etc/rc.local`
   * If all else fails, copy `/boot/wpa_supplicant.conf.sample` to `/boot/wpa_supplicant.conf` and edit out the `TEMP` variables to your desired settings.
 * Note: if you get an error about `read-only filesystem`, you may have to `sudo -i` and run `/root/bin/remountfs_rw`.
+* Try `date` to ensure the system clock is set correctly. If it is too far off, SSL/TLS Authentication will fail, preventing the installation from completing. You can set the date like `date -s "2 JAN 2022 15:04:05"`
+* Try `tail -f /boot/teslausb-headless-setup.log` to watch the logs during installation, which may shed some light on any errors occurring. Press `Ctrl-C` to stop watching logs.
 
 More troubleshooting information in the [wiki](https://github.com/marcone/teslausb/wiki/Troubleshooting)
 

--- a/doc/SetupRSync.md
+++ b/doc/SetupRSync.md
@@ -6,8 +6,8 @@ Since sftp/rsync accesses a computer through SSH the only requirement for hostin
 You will need the username and host/IP of the storage server, as well as the path for the files to go in, and the storage server will need to allow SSH.
 
 This guide makes the following assumptions:
-* You are running your own ftp/rsync server that you have admin rights to, or can at least add a public key to its `~/.ssh/authorized_keys` file.
-* The ftp/rsync server has rsync installed (raspbian automatically does)
+* You are running your own sftp/rsync server that you have admin rights to, or can at least add a public key to its `~/.ssh/authorized_keys` file.
+* The sftp/rsync server has rsync installed (raspbian automatically does)
 
 # Step 1: Authentication
 Similar to sftp, rsync by default uses ssh to connect to a remote server and transfer files. This guide will use a generated ssh keypair, hence the first assumption above.
@@ -17,31 +17,33 @@ Similar to sftp, rsync by default uses ssh to connect to a remote server and tra
    sudo -i
    ```
 
+1. Remount the file system as read-write:
+   ```
+   bin/remountfs_rw
+   ```
+
 1. Run these commands to to generate an ssh key for the `root` user:
    ```
    ssh-keygen
    ```
 
-1. Add the contents of the newly generated `/root/.ssh/id_rsa.pub` file from your teslausb pi to the storage server's `~/.ssh/authorized_keys` file. You can do this by connectin via ssh to the archive server from the computer you're using to set up the Pi, editing the `~/.ssh/authorized_keys` in nano, and pasting in the content of the `/root/.ssh/id_rsa.pub` file from the teslausb Pi.
-
-1. Lastly, you will need to authorize the connection to the FTP/Rsync server and test that the key works, so try connecting to the server (through ssh), and **when you are asked if you wish to continue connecting type `yes`**
+1. Copy the key to the storage server. This will also add the server to `.ssh/known_hosts`:
    ```
-   ssh user@archiveserver
+   ssh-copy-id user@archiveserver
    ```
-   If you do not do this then rsync will fail to connect and thus fail to archive your clips.
 
 # Step 2: Exports
 Run this command to cause the setup processes which you'll resume in the main instructions to use rsync:
 
 ```
 export ARCHIVE_SYSTEM=rsync
-export RSYNC_USER=<ftp username>
-export RSYNC_SERVER=<ftp IP/host>
+export RSYNC_USER=<sftp username>
+export RSYNC_SERVER=<sftp IP/host>
 export RSYNC_PATH=<destination path to save in>
 ```
 Explanations for each:
 * `ARCHIVE_SYSTEM`: `rsync` for enabling rsync
-* `RSYNC_USER`: The user on the FTP server
+* `RSYNC_USER`: The user on the SFTP server
 * `RSYNC_SERVER`: The IP address/hostname of the destination machine
 * `RSYNC_PATH`: The path on the destination machine where the files will be saved
 

--- a/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
+++ b/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
@@ -22,6 +22,8 @@ export SHARE_PASSWORD=password
 # export CIFS_SEC="ntlm"
 
 # Variables for rsync archiving
+# For instructions setting up SSH Public Key authentication, view:
+# https://github.com/marcone/teslausb/blob/main-dev/doc/SetupRSync.md#step-1-authentication
 #export ARCHIVE_SYSTEM=rsync
 #export RSYNC_USER=username
 #export RSYNC_SERVER=hostname_or_ip


### PR DESCRIPTION
Replace instructions for manually populating ssh configuration on rsync server with ssh-copy-id.
Replace 'ftp' with 'sftp'.
Link to configure rsync/rclone from One-step setup.