### PR TITLE
Add options to define root SSH public key and disable password auth

### DIFF
--- a/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
+++ b/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
@@ -136,6 +136,13 @@ export WIFIPASS='your_pass'
 # Uncomment if you want to override the default hostname of "teslausb"
 # export TESLAUSB_HOSTNAME=teslausb-Model3
 
+# uncomment if you want to define an SSH public key that can be utilized to
+# SSH into teslausb as root
+# export SSH_ROOT_PUBLIC_KEY='ssh-rsa AAAAB3NzaC1yc2EAAAADAQABA....etc'
+
+# uncoment if you want to disable password SSH authentication for all users
+# export SSH_DISABLE_PASSWORD_AUTHENTICATION=true
+
 # Uncomment if setting up Pushover push notifications
 # export PUSHOVER_ENABLED=true
 # export PUSHOVER_USER_KEY=user_key

--- a/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
+++ b/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
@@ -136,11 +136,10 @@ export WIFIPASS='your_pass'
 # Uncomment if you want to override the default hostname of "teslausb"
 # export TESLAUSB_HOSTNAME=teslausb-Model3
 
-# uncomment if you want to define an SSH public key that can be utilized to
-# SSH into teslausb as root
-# export SSH_ROOT_PUBLIC_KEY='ssh-rsa AAAAB3NzaC1yc2EAAAADAQABA....etc'
+# uncomment to define an SSH public key that can be utilized to SSH into teslausb as root
+# export SSH_ROOT_PUBLIC_KEY='ssh-rsa AAAAB3NzaC1yc2EAAAADAQABA... user@host.domain'
 
-# uncoment if you want to disable password SSH authentication for all users
+# uncoment to disable password SSH authentication for all users
 # export SSH_DISABLE_PASSWORD_AUTHENTICATION=true
 
 # Uncomment if setting up Pushover push notifications

--- a/setup/pi/configure-ssh.sh
+++ b/setup/pi/configure-ssh.sh
@@ -1,23 +1,17 @@
 #!/bin/bash -eu
 
 setup_progress "configuring ssh"
-auth_keys_file='/root/.ssh/authorized_keys'
-sshd_config_file='/etc/ssh/sshd_config'
 
-# If the user has defined a public key for root SSH access apply it
-if ! [ -z "${SSH_ROOT_PUBLIC_KEY}" ]
+# If requested, add the desired SSH public key into /root/.ssh/authorized_keys
+if [ "${SSH_ROOT_PUBLIC_KEY:-false}" != "false" ] && [ -n "${SSH_ROOT_PUBLIC_KEY}" ]
 then
-  # Don't overwrite the auth_keys_file if it already exists as the user may have modified it further
-  if ! [ -s "${auth_keys_file}" ]
-  then
-    echo "${SSH_ROOT_PUBLIC_KEY}" > "${auth_keys_file}"
-  fi
+  echo "${SSH_ROOT_PUBLIC_KEY}" > '/root/.ssh/authorized_keys'
 fi
 
-# Disable SSH Password Authentication if the user requested us to do so
+# If requested, disable SSH Password Authentication
 if [ "${SSH_DISABLE_PASSWORD_AUTHENTICATION:-false}" = "true" ]
 then
-  sed -i 's/#PasswordAuthentication yes/PasswordAuthentication no/' ${sshd_config_file}
+  sed -i 's/#PasswordAuthentication yes/PasswordAuthentication no/' '/etc/ssh/sshd_config'
   systemctl reload sshd
 fi
 

--- a/setup/pi/configure-ssh.sh
+++ b/setup/pi/configure-ssh.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -eu
+
+setup_progress "configuring ssh"
+auth_keys_file='/root/.ssh/authorized_keys'
+sshd_config_file='/etc/ssh/sshd_config'
+
+# If the user has defined a public key for root SSH access apply it
+if ! [ -z "${SSH_ROOT_PUBLIC_KEY}" ]
+then
+  # Don't overwrite the auth_keys_file if it already exists as the user may have modified it further
+  if ! [ -s "${auth_keys_file}" ]
+  then
+    echo "${SSH_ROOT_PUBLIC_KEY}" > "${auth_keys_file}"
+  fi
+fi
+
+# Disable SSH Password Authentication if the user requested us to do so
+if [ "${SSH_DISABLE_PASSWORD_AUTHENTICATION:-false}" = "true" ]
+then
+  sed -i 's/#PasswordAuthentication yes/PasswordAuthentication no/' ${sshd_config_file}
+  systemctl reload sshd
+fi
+
+setup_progress "done configuring ssh"

--- a/setup/pi/configure-ssh.sh
+++ b/setup/pi/configure-ssh.sh
@@ -3,7 +3,7 @@
 setup_progress "configuring ssh"
 
 # If requested, add the desired SSH public key into /root/.ssh/authorized_keys
-if [ "${SSH_ROOT_PUBLIC_KEY:-false}" != "false" ] && [ -n "${SSH_ROOT_PUBLIC_KEY}" ]
+if [ -n "${SSH_ROOT_PUBLIC_KEY:-}" ]
 then
   echo "${SSH_ROOT_PUBLIC_KEY}" > '/root/.ssh/authorized_keys'
 fi

--- a/setup/pi/setup-teslausb
+++ b/setup/pi/setup-teslausb
@@ -881,6 +881,9 @@ copy_script setup/pi/configure-automount.sh /tmp
 copy_script setup/pi/configure-web.sh /tmp
 /tmp/configure-web.sh
 
+copy_script setup/pi/configure-ssh.sh /tmp
+/tmp/configure-ssh.sh
+
 # source setup-teslausb from .bashrc to set up completion
 if ! grep -q envsetup.sh /root/.bashrc
 then


### PR DESCRIPTION
- Added `SSH_ROOT_PUBLIC_KEY` for users to define an SSH public key for SSHing into the root user
- Added `SSH_DISABLE_PASSWORD_AUTHENTICATION` for users to disable password SSH authentication