### PR TITLE
Added customizable username variable for Discord webhook

### DIFF
--- a/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
+++ b/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
@@ -175,9 +175,10 @@ export WIFIPASS='your_pass'
 # export IFTTT_EVENT_NAME=put_your_event_name_here
 # export IFTTT_KEY=put_your_key_here
 
-# Uncomment if setting up Discord push notifications
+# Uncomment if setting up Discord push notifications. Be sure to set DISCORD_USERNAME
 # export DISCORD_ENABLED=true
 # export DISCORD_WEBHOOK_URL=put_your_webhook_url_here
+# export DISCORD_USERNAME=desired_discord_username
 
 # Uncomment if setting up AWS SNS notifications
 # export SNS_ENABLED=true

--- a/run/send-push-message
+++ b/run/send-push-message
@@ -28,7 +28,7 @@ function send_discord() {
   log "Sending Discord message."
 
   curl -H "Content-Type: application/json" -d \
-    '{"username": "'"$title"'", "content": "'"$message"'"}' \
+    '{"username": "'"$DISCORD_USERNAME"'", "content": "'"$message"'"}' \
     "$DISCORD_WEBHOOK_URL"
 }
 


### PR DESCRIPTION
Some friends and I have always wanted to have our Discord webhook names to be different than our teslausb hostnames. I thought I'd get the ball rolling by doing something about it.

I am not 100% sure this is the way to do it, so please let me know what I should differently if this is not the correct way to go about this.