### PR TITLE
Integrate Signal API alerting

### DIFF
--- a/doc/SetupRSync.md
+++ b/doc/SetupRSync.md
@@ -58,3 +58,8 @@ export RSYNC_PATH=/mnt/PIHDD/TeslaCam/
 Additional options for rsync over ssh can be configured using `~/.ssh/config` such as port number. To see all available options visit [the man page](https://linux.die.net/man/5/ssh_config).
 
 Stay in the `sudo -i` session return to the section "Set up the USB storage functionality" in the [main instructions](../README.md).
+
+# Step 3: Networking
+If you have a firewall between the server and teslausb you will need to allow ports 22 and ICMP.
+Port 22 is used for the rsync service
+ICMP is used to verify the archive is reachable from teslausb

--- a/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
+++ b/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
@@ -164,7 +164,8 @@ export WIFIPASS='your_pass'
 # set a custom title by setting the following variable.
 # export NOTIFICATION_TITLE="TeslaUSB Notification"
 
-# Uncomment if setting up Signal notifications
+# Uncomment if setting up Signal_cli notifications
+# export SIGNAL_ENABLED=true
 # export URL_PORT=http://<url>:8080
 # export FROM_NUM=country_code_and_number_configured_with_signal
 # export TO_NUM=country_code_and_number_configured_with_signal

--- a/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
+++ b/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
@@ -166,9 +166,9 @@ export WIFIPASS='your_pass'
 
 # Uncomment if setting up Signal_cli notifications
 # export SIGNAL_ENABLED=true
-# export URL_PORT=http://<url>:8080
-# export FROM_NUM=country_code_and_number_configured_with_signal
-# export TO_NUM=country_code_and_number_configured_with_signal
+# export SIGNAL_URL=http://<url>:8080
+# export SIGNAL_FROM_NUM=country_code_and_number_configured_with_signal
+# export SIGNAL_TO_NUM=country_code_and_number_configured_with_signal
 
 # Uncomment if setting up Pushover push notifications
 # export PUSHOVER_ENABLED=true

--- a/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
+++ b/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
@@ -164,6 +164,11 @@ export WIFIPASS='your_pass'
 # set a custom title by setting the following variable.
 # export NOTIFICATION_TITLE="TeslaUSB Notification"
 
+# Uncomment if setting up Signal notifications
+# export URL_PORT=http://<url>:8080
+# export FROM_NUM=country_code_and_number_configured_with_signal
+# export TO_NUM=country_code_and_number_configured_with_signal
+
 # Uncomment if setting up Pushover push notifications
 # export PUSHOVER_ENABLED=true
 # export PUSHOVER_USER_KEY=user_key

--- a/run/send-push-message
+++ b/run/send-push-message
@@ -6,8 +6,8 @@ type="${3:-}"
 
 function send_signal () {
   log "Sending Pushover message."
-  curl -X POST -H "Content-Type: application/json" 'http://'${url_port}'/v2/send4' \
-     -d '{"message":"'${message}'", "number": "'${from_num}'", "recipients": [ "'${to_num}'" ]}'
+  curl -X POST -H "Content-Type: application/json" ''$URL_PORT'/v2/send4' \
+     -d '{"message":"'$title': '$message'", "number": "'$FROM_NUM'", "recipients": [ "'$TO_NUM'" ]}'
  }
 
 function send_pushover () {

--- a/run/send-push-message
+++ b/run/send-push-message
@@ -7,7 +7,7 @@ type="${3:-}"
 function send_signal () {
   log "Sending Signal message."
   
-  curl -X POST -H "Content-Type: application/json" ''$URL_PORT'/v2/send' \
+  curl -X POST -H "Content-Type: application/json" $URL_PORT'/v2/send' \
      -d '{"message":"'$title': '$message'", "number": "'$FROM_NUM'", "recipients": [ "'$TO_NUM'" ]}'
  }
 

--- a/run/send-push-message
+++ b/run/send-push-message
@@ -7,8 +7,8 @@ type="${3:-}"
 function send_signal () {
   log "Sending Signal message."
   
-  curl -X POST -H "Content-Type: application/json" $URL_PORT'/v2/send' \
-     -d '{"message": "'"$message"'", "number": "'$FROM_NUM'", "recipients": [ "'$TO_NUM'" ]}'
+  curl -X POST -H "Content-Type: application/json" $SIGNAL_URL'/v2/send' \
+     -d '{"message": "'"$message"'", "number": "'$SIGNAL_FROM_NUM'", "recipients": [ "'$SIGNAL_TO_NUM'" ]}'
  }
 
 function send_pushover () {

--- a/run/send-push-message
+++ b/run/send-push-message
@@ -8,7 +8,7 @@ function send_signal () {
   log "Sending Signal message."
   
   curl -X POST -H "Content-Type: application/json" $URL_PORT'/v2/send' \
-     -d '{"message":"'$title'": "'$message'", "number": "'$FROM_NUM'", "recipients": [ "'$TO_NUM'" ]}'
+     -d '{"message": "'"$message"'", "number": "'$FROM_NUM'", "recipients": [ "'$TO_NUM'" ]}'
  }
 
 function send_pushover () {

--- a/run/send-push-message
+++ b/run/send-push-message
@@ -7,7 +7,7 @@ type="${3:-}"
 function send_signal () {
   log "Sending Signal message."
   
-  curl -X POST -H "Content-Type: application/json" ''$URL_PORT'/v2/send4' \
+  curl -X POST -H "Content-Type: application/json" ''$URL_PORT'/v2/send' \
      -d '{"message":"'$title': '$message'", "number": "'$FROM_NUM'", "recipients": [ "'$TO_NUM'" ]}'
  }
 

--- a/run/send-push-message
+++ b/run/send-push-message
@@ -5,7 +5,8 @@ message="$2"
 type="${3:-}"
 
 function send_signal () {
-  log "Sending Pushover message."
+  log "Sending Signal message."
+  
   curl -X POST -H "Content-Type: application/json" ''$URL_PORT'/v2/send4' \
      -d '{"message":"'$title': '$message'", "number": "'$FROM_NUM'", "recipients": [ "'$TO_NUM'" ]}'
  }

--- a/run/send-push-message
+++ b/run/send-push-message
@@ -8,7 +8,7 @@ function send_signal () {
   log "Sending Signal message."
   
   curl -X POST -H "Content-Type: application/json" $URL_PORT'/v2/send' \
-     -d '{"message":"'$title': '$message'", "number": "'$FROM_NUM'", "recipients": [ "'$TO_NUM'" ]}'
+     -d '{"message":"'$title'": "'$message'", "number": "'$FROM_NUM'", "recipients": [ "'$TO_NUM'" ]}'
  }
 
 function send_pushover () {

--- a/run/send-push-message
+++ b/run/send-push-message
@@ -4,6 +4,11 @@ title="$1"
 message="$2"
 type="${3:-}"
 
+function send_signal () {
+  curl -X POST -H "Content-Type: application/json" 'http://'${url_port}'/v2/send4' \
+     -d '{"message":"'${message}'", "number": "'${from_num}'", "recipients": [ "'${to_num}'" ]}'
+ }
+
 function send_pushover () {
   log "Sending Pushover message."
 

--- a/run/send-push-message
+++ b/run/send-push-message
@@ -91,6 +91,7 @@ function send_shell () {
 
 log "$message"
 
+[ "${SIGNAL_ENABLED:-false}" = "true" ] && send_signal
 [ "${PUSHOVER_ENABLED:-false}" = "true" ] && send_pushover
 [ "${GOTIFY_ENABLED:-false}" = "true" ] && send_gotify
 [ "${DISCORD_ENABLED:-false}" = "true" ] && send_discord

--- a/run/send-push-message
+++ b/run/send-push-message
@@ -5,6 +5,7 @@ message="$2"
 type="${3:-}"
 
 function send_signal () {
+  log "Sending Pushover message."
   curl -X POST -H "Content-Type: application/json" 'http://'${url_port}'/v2/send4' \
      -d '{"message":"'${message}'", "number": "'${from_num}'", "recipients": [ "'${to_num}'" ]}'
  }

--- a/setup/pi/configure.sh
+++ b/setup/pi/configure.sh
@@ -254,7 +254,7 @@ function install_matrix_packages () {
 function check_signal_configuration () {
   if [ "${SIGNAL_ENABLED:-false}" = "true" ]
   then
-    if [ -z "${URL_PORT+x}" ] || [  "${TO_NUM}" = "country_code_and_number_configured_with_signal" ] || [  "${FROM_NUM}" = "country_code_and_number_configured_with_signal"  ]
+    if [ -z "${SIGNAL_URL+x}" ] || [  "${SIGNALTO_NUM}" = "country_code_and_number_configured_with_signal" ] || [  "${SIGNAL_FROM_NUM}" = "country_code_and_number_configured_with_signal"  ]
     then
       log_progress "STOP: You're trying to setup Signal but didn't provide a URL."
       log_progress "Define the variables like this:"
@@ -262,7 +262,7 @@ function check_signal_configuration () {
       log_progress "export TO_NUM=put_phone_number_associated_with_signal_including_country_code"
       log_progress "export FROM_NUM=put_phone_number_associated_with_signal_including_country_code_to_send_to"
       exit 1
-    elif [ "${URL_PORT}" = "http://<url>:8080" ] || [  "${TO_NUM}" = "country_code_and_number_configured_with_signal" ] || [  "${FROM_NUM}" = "country_code_and_number_configured_with_signal"  ]
+    elif [ "${SIGNAL_URL}" = "http://<url>:8080" ] || [  "${SIGNAL_TO_NUM}" = "country_code_and_number_configured_with_signal" ] || [  "${SIGNAL_FROM_NUM}" = "country_code_and_number_configured_with_signal"  ]
     then
       log_progress "STOP: You're trying to setup Signal, but didn't replace the default URL, to number, or from number"
       exit 1

--- a/setup/pi/configure.sh
+++ b/setup/pi/configure.sh
@@ -258,9 +258,9 @@ function check_signal_configuration () {
     then
       log_progress "STOP: You're trying to setup Signal but didn't provide a URL."
       log_progress "Define the variables like this:"
-      log_progress "export URL_PORT=put_protocol_ip/hostname_portnumber"
-      log_progress "export TO_NUM=put_phone_number_associated_with_signal_including_country_code"
-      log_progress "export FROM_NUM=put_phone_number_associated_with_signal_including_country_code_to_send_to"
+      log_progress "export SIGNAL_URL=put_protocol_ip/hostname_portnumber"
+      log_progress "export SIGNAL_TO_NUM=put_phone_number_associated_with_signal_including_country_code"
+      log_progress "export SIGNAL_FROM_NUM=put_phone_number_associated_with_signal_including_country_code_to_send_to"
       exit 1
     elif [ "${SIGNAL_URL}" = "http://<url>:8080" ] || [  "${SIGNAL_TO_NUM}" = "country_code_and_number_configured_with_signal" ] || [  "${SIGNAL_FROM_NUM}" = "country_code_and_number_configured_with_signal"  ]
     then

--- a/setup/pi/configure.sh
+++ b/setup/pi/configure.sh
@@ -254,7 +254,7 @@ function install_matrix_packages () {
 function check_signal_configuration () {
   if [ "${SIGNAL_ENABLED:-false}" = "true" ]
   then
-    if [ -z "${SIGNAL_URL+x}" ] || [  "${SIGNALTO_NUM}" = "country_code_and_number_configured_with_signal" ] || [  "${SIGNAL_FROM_NUM}" = "country_code_and_number_configured_with_signal"  ]
+    if [ -z "${SIGNAL_URL+x}" ] || [  "${SIGNALTO_NUM+x}" = "country_code_and_number_configured_with_signal" ] || [  "${SIGNAL_FROM_NUM+x}" = "country_code_and_number_configured_with_signal"  ]
     then
       log_progress "STOP: You're trying to setup Signal but didn't provide a URL."
       log_progress "Define the variables like this:"

--- a/setup/pi/configure.sh
+++ b/setup/pi/configure.sh
@@ -251,6 +251,25 @@ function install_matrix_packages () {
   pip3 install matrix-nio
 }
 
+function check_signal_configuration () {
+  if [ "${SIGNAL_ENABLED:-false}" = "true" ]
+  then
+    if [ -z "${URL_PORT+x}" ] || [  "${TO_NUM}" = "country_code_and_number_configured_with_signal" ] || [  "${FROM_NUM}" = "country_code_and_number_configured_with_signal"  ]
+    then
+      log_progress "STOP: You're trying to setup Signal but didn't provide a URL."
+      log_progress "Define the variables like this:"
+      log_progress "export URL_PORT=put_protocol_ip/hostname_portnumber"
+      log_progress "export TO_NUM=put_phone_number_associated_with_signal_including_country_code"
+      log_progress "export FROM_NUM=put_phone_number_associated_with_signal_including_country_code_to_send_to"
+      exit 1
+    elif [ "${URL_PORT}" = "http://<url>:8080" ] || [  "${TO_NUM}" = "country_code_and_number_configured_with_signal" ] || [  "${FROM_NUM}" = "country_code_and_number_configured_with_signal"  ]
+    then
+      log_progress "STOP: You're trying to setup Signal, but didn't replace the default URL, to number, or from number"
+      exit 1
+    fi
+  fi
+}
+
 function check_pushover_configuration () {
   if [ "${PUSHOVER_ENABLED:-false}" = "true" ]
   then


### PR DESCRIPTION
Added Signal as an alerting option following code structure of other alerting platforms. All changes are additions and shouldn’t break any current installs. 

I added a couple of networking notes to the rsync setup document. Having separate vlans with a zero trust setup had me digging to figure out how Teslausb was checking if the archive was available. Added clarification for ICMP usage as well as rsync port.

