### PR TITLE
Fix user requested root SSH public key by creating /root/.ssh directory

### DIFF
--- a/setup/pi/configure-ssh.sh
+++ b/setup/pi/configure-ssh.sh
@@ -5,7 +5,9 @@ setup_progress "configuring ssh"
 # If requested, add the desired SSH public key into /root/.ssh/authorized_keys
 if [ -n "${SSH_ROOT_PUBLIC_KEY:-}" ]
 then
-  echo "${SSH_ROOT_PUBLIC_KEY}" > '/root/.ssh/authorized_keys'
+  ssh_dir='/root/.ssh'
+  mkdir -p $ssh_dir
+  echo "${SSH_ROOT_PUBLIC_KEY}" > "${ssh_dir}/authorized_keys"
 fi
 
 # If requested, disable SSH Password Authentication


### PR DESCRIPTION
Fixes 756, adds `/root/.ssh` directory when user requests an SSH Public Key be added to `/root/.ssh/authorized_keys` for key-based SSH authentication.