### PR TITLE
Add support for music rsync 

### DIFF
--- a/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
+++ b/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
@@ -91,11 +91,11 @@ export CAM_SIZE=30G
 #export MUSIC_SIZE=4G
 #export BOOMBOX_SIZE=100M
 
-# If you want to automatically copy music from a CIFS share every time
-# the Pi connects to wifi, set the following variable. The share is
-# assumed to exist on the same server as the archive share. It can
-# be the same share as the share used for backing up recordings, but
-# the folder needs to be different.
+# If you want to automatically copy music from either a CIFS share or a
+# remote folder with rsync every time the Pi connects to wifi,
+# set the following variable. The share is assumed to exist on the same
+# server as the archive share. It can be the same share as the share used
+# for backing up recordings, but the folder needs to be different.
 # export MUSIC_SHARE_NAME=your_music_share/music_folder
 
 # Wifi setup information. Note that Raspberry Pi Zero W only supports 2.4 GHz

--- a/run/rsync_archive/copy-music.sh
+++ b/run/rsync_archive/copy-music.sh
@@ -1,0 +1,80 @@
+#!/bin/bash -eu
+
+SRC="${RSYNC_USER}@${RSYNC_SERVER}:${MUSIC_SHARE_NAME}"
+DST="${MUSIC_MOUNT}"
+LOG="/tmp/rsyncmusiclog.txt"
+
+# check that DST is the mounted disk image, not the mountpoint directory
+if ! findmnt --mountpoint "$DST" > /dev/null
+then
+  log "$DST not mounted, skipping music sync"
+  exit
+fi
+
+function connectionmonitor {
+  while true
+  do
+    for _ in {1..10}
+    do
+      if timeout 3 /root/bin/archive-is-reachable.sh "$ARCHIVE_SERVER"
+      then
+        # sleep and then continue outer loop
+        sleep 5
+        continue 2
+      fi
+    done
+    log "connection dead, killing copy-music"
+    # Give rsync a chance to clean up before killing it hard.
+    killall rsync || true
+    sleep 2
+    killall -9 rsync || true
+    kill -9 "$1" || true
+    return
+  done
+}
+
+function do_music_sync {
+  log "Syncing music from remote..."
+
+  connectionmonitor $$ &
+
+  if ! rsync -rtum --no-human-readable --exclude=.fseventsd/*** --exclude=*.DS_Store --exclude=.metadata_never_index \
+                --exclude="System Volume Information/***" \
+                --delete --modify-window=2 --info=stats2 "$SRC/" "$DST" &> "$LOG"
+  then
+    log "rsync failed with error $?"
+  fi
+
+  # Stop the connection monitor.
+  kill %1 || true
+
+  # remove empty directories
+  find "$DST" -depth -type d -empty -delete || true
+
+  # parse log for relevant info
+  declare -i NUM_FILES_COPIED
+  NUM_FILES_COPIED=$(($(sed -n -e 's/\(^Number of regular files transferred: \)\([[:digit:]]\+\).*/\2/p' "$LOG")))
+  declare -i NUM_FILES_DELETED
+  NUM_FILES_DELETED=$(($(sed -n -e 's/\(^Number of deleted files: [[:digit:]]\+ (reg: \)\([[:digit:]]\+\)*.*/\2/p' "$LOG")))
+  declare -i TOTAL_FILES
+  TOTAL_FILES=$(sed -n -e 's/\(^Number of files: [[:digit:]]\+ (reg: \)\([[:digit:]]\+\)*.*/\2/p' "$LOG")
+  declare -i NUM_FILES_ERROR
+  NUM_FILES_ERROR=$(($(grep -c "failed to open" $LOG || true)))
+
+  declare -i NUM_FILES_SKIPPED=$((TOTAL_FILES-NUM_FILES_COPIED))
+  NUM_FILES_COPIED=$((NUM_FILES_COPIED-NUM_FILES_ERROR))
+
+  local message="Copied $NUM_FILES_COPIED music file(s), deleted $NUM_FILES_DELETED, skipped $NUM_FILES_SKIPPED previously-copied files, and encountered $NUM_FILES_ERROR errors."
+
+  if [ $NUM_FILES_COPIED -ne 0 ] || [ $NUM_FILES_DELETED -ne 0 ] || [ $NUM_FILES_ERROR -ne 0 ]
+  then
+    /root/bin/send-push-message "$NOTIFICATION_TITLE:" "$message"
+  else
+    log "$message"
+  fi
+}
+
+if ! do_music_sync
+then
+  log "Error while syncing music"
+fi

--- a/setup/pi/configure.sh
+++ b/setup/pi/configure.sh
@@ -225,7 +225,7 @@ function install_archive_scripts () {
   copy_script "$archive_module"/connect-archive.sh "$install_path"
   copy_script "$archive_module"/disconnect-archive.sh "$install_path"
   copy_script "$archive_module"/archive-is-reachable.sh "$install_path"
-  if [ -n "${MUSIC_SHARE_NAME:+x}" ] && grep cifs <<< "$archive_module"
+  if [ -n "${MUSIC_SHARE_NAME:+x}" ] && [ -e "$archive_module"/copy-music.sh ]
   then
     copy_script "$archive_module"/copy-music.sh "$install_path"
   fi


### PR DESCRIPTION
Somehow the rsync_archive was missing the copy-music.sh script. Someone else already tried it, but you rejected his PR 
(see https://github.com/marcone/teslausb/pull/641)
I checked his script and also looked into your script from cifs_archive and found it quite funny, that you are using rsync in cifs archive anyway. So I took your script, changed SRC to use the available RSYNC variables from setup and just removed some cifs specific parts. 
I also adjusted the install script to be more generic on copying the copy-music.sh script.
From what I saw, I think this should be complete now, as everything else is already implemented quite generic.