### PR TITLE
Minor tweaks for armbian orange pi zero 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,33 @@
 # teslausb
-Armbian orange pi zero 2 setup *tweaks
-  pacakages:
-  xfsprogs
-  dos2unix
-  hping3
-  libxxhash0
-  autofs
-  python3-pip
-  nginx
-  fcgiwrap
-  libnginx-mod-http-fancyindex
-  libfuse-dev
-  exfatprogs
-  sntp
+## Armbian orange pi zero 2 setup *tweaks
 
-first boot setup wifi with `nmtui and make a wpa_supplicant.conf at /etc/wpa_supplicant/wpa_supplicant.conf
-reboot # to commit network changes
-# now run the teslausb install
+apt pacakages:
+
+* xfsprogs
+* dos2unix
+* hping3
+* libxxhash0
+* autofs
+* python3-pip
+* nginx
+* fcgiwrap
+* libnginx-mod-http-fancyindex
+* libfuse-dev
+* exfatprogs
+* sntp
+
+first boot setup wifi with `nmtui`
+
+make a wpa_supplicant.conf at /etc/wpa_supplicant/wpa_supplicant.conf
+
+reboot
+
+to commit network changes
+
+now run the teslausb install
+
 ```curl https://raw.githubusercontent.com/marcone/teslausb/main-dev/setup/generic/install.sh | bash```
+
 if you have the changes for createbackingfiles.sh in this repo your install should work and run fine, you may have to restart it after making the mountpoints for the shares/disk images
 
 ## Intro

--- a/README.md
+++ b/README.md
@@ -1,4 +1,24 @@
 # teslausb
+Armbian orange pi zero 2 setup *tweaks
+  pacakages:
+  xfsprogs
+  dos2unix
+  hping3
+  libxxhash0
+  autofs
+  python3-pip
+  nginx
+  fcgiwrap
+  libnginx-mod-http-fancyindex
+  libfuse-dev
+  exfatprogs
+  sntp
+
+first boot setup wifi with `nmtui and make a wpa_supplicant.conf at /etc/wpa_supplicant/wpa_supplicant.conf
+reboot # to commit network changes
+# now run the teslausb install
+```curl https://raw.githubusercontent.com/marcone/teslausb/main-dev/setup/generic/install.sh | bash```
+if you have the changes for createbackingfiles.sh in this repo your install should work and run fine, you may have to restart it after making the mountpoints for the shares/disk images
 
 ## Intro
 

--- a/setup/pi/create-backingfiles.sh
+++ b/setup/pi/create-backingfiles.sh
@@ -84,7 +84,7 @@ function add_drive () {
   local useexfat="$5"
 
   log_progress "Allocating ${size}K for $filename..."
-  fallocate -l "$size"K "$filename"
+  fallocate -l "${size}K" "$filename"
   if [ "$useexfat" = true  ]
   then
     echo "type=7" | sfdisk "$filename" > /dev/null
@@ -99,9 +99,9 @@ function add_drive () {
   log_progress "Creating filesystem with label '$label'"
   if [ "$useexfat" = true  ]
   then
-    mkfs.exfat "$loopdev" -L "$label"
+    mkfs.exfat "$loopdev" -n "$label"
   else
-    mkfs.vfat "$loopdev" -F 32 -n "$label"
+    mkfs.vfat -I "$loopdev" -F 32 -n "$label"
   fi
   losetup -d "$loopdev"
 


### PR DESCRIPTION
Minor tweaks for armbian orange pi zero 2, mostly the mkfs commands syntax in createbackingfiles.sh, and a note about pre-reqs or dealing with the armbian image on the orange pi zero 2