### PR TITLE
More available archive check for rsync case

### DIFF
--- a/run/rsync_archive/archive-is-reachable.sh
+++ b/run/rsync_archive/archive-is-reachable.sh
@@ -2,4 +2,4 @@
 
 ARCHIVE_HOST_NAME="$1"
 
-ping -q -w 1 -c 1 "$ARCHIVE_HOST_NAME" > /dev/null 2>&1
+ssh -q "$RSYNC_USER"@"$ARCHIVE_HOST_NAME" exit

--- a/run/rsync_archive/archive-is-reachable.sh
+++ b/run/rsync_archive/archive-is-reachable.sh
@@ -2,4 +2,4 @@
 
 ARCHIVE_HOST_NAME="$1"
 
-ssh -q "$RSYNC_USER"@"$ARCHIVE_HOST_NAME" exit
+ssh -q -o ConnectTimeout=1 "$RSYNC_USER"@"$ARCHIVE_HOST_NAME" exit


### PR DESCRIPTION
Many ISPs block ICMP Ping traffic to reduce the attack surface of their customers.  My ISP does this, yet I want to rsync my clips to my home NAS which uses a dynamic DNS entry, etc.

To get around this, I instead have to check if I can establish an SSH connection rather than receive a ping response.

I think that this is actually a better check anyway because an ssh connection is needed for rsync.  This line returns similar process codes on success (exit 0) and failure (exit non-zero) as the prior ping command and thus is a complete drop-in replacement for the other command.