### PR TITLE
verify-configuration.sh: missing CM4 

### DIFF
--- a/setup/pi/verify-configuration.sh
+++ b/setup/pi/verify-configuration.sh
@@ -26,6 +26,10 @@ function check_supported_hardware () {
   then
     return
   fi
+  if grep -q 'Raspberry Pi Compute Module 4' /sys/firmware/devicetree/base/model
+  then
+    return
+  fi
   setup_progress "STOP: unsupported hardware: '$(cat /sys/firmware/devicetree/base/model)'"
   setup_progress "(only Pi Zero W and Pi 4 have the necessary hardware to run teslausb)"
   exit 1


### PR DESCRIPTION
Would be nice to have support for "Raspberry Pi Compute Module 4". 
Is it enough just adding this line in the "verify-configuration.sh"?
Thanks!  