### PR TITLE
TeslaFi support for keeping car awake

### DIFF
--- a/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
+++ b/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
@@ -259,8 +259,28 @@ export WIFIPASS='your_pass'
 # Android: https://play.google.com/store/apps/details?id=net.leveugle.teslatokens
 # iOS: https://apps.apple.com/us/app/auth-app-for-tesla/id1552058613#?platform=iphone
 #
+# TeslaFi Subscriber?
+#   If you're a TeslaFi user, you may consider keeping the car wake using
+#   TeslaFi API instead. The advantage is not having to expose Tesla's Token
+#   and other info in this file as plain text, which is a vulnerability (as
+#   noted above. 'PIN to Drive' is not necessary in this case.
+#   The TeslaFi API token can easily be revoked and a new one generated at
+#   anytime. TeslaFi also allows selective command(s) enablement (e.g. disable
+#   uneeded commands), further decreasing vulnerability.
+# 
+# GENERATE/REVOKE TESLAFI API TOKEN: Log into your TeslaFi account.
+#   Navigate to Settings -> Tesla API -> API Token (tab)
+#
+# ENABLE/DISABLE TESLAFI API COMMANDS: Verify the 'Resume Polling' (wake)
+#   command is enabled. Do not confused this with the 'Wake Vehicle' command.
+#   Navigate to Settings -> Tesla API -> Commands (tab)
+#
+# NOTE: Both APIs should NOT be used at the same time. Choose only one.
+#
 # export TESLA_REFRESH_TOKEN='YOUR_REFRESH_TOKEN_GOES_HERE'
+# export TESLAFI_API_TOKEN='YOUR_TESLAFI_API_TOKEN_GOES_HERE'
 
+# TESLA API ONLY (Do not configure if using TeslaFi API):
 # If you have more than one Tesla vehicle on the account, you must also provide
 # the name or VIN for the vehicle for which this TeslaUSB install will be used,
 # so that TeslaUSB can keep the correct vehicle awake.
@@ -268,6 +288,7 @@ export WIFIPASS='your_pass'
 # export TESLA_NAME="Elon's CyberTruck"
 # export TESLA_VIN=5YJ3E1EA4JF000001
 #
+# TESLA API ONLY (Do not configure if using TeslaFi API):
 # By default, TeslaUSB uses a combination of APIs to keep the car awake,
 # similar to how to the Tesla app can wake up the car.
 # If you find your car isn't staying awake, you can try setting the
@@ -300,7 +321,7 @@ export WIFIPASS='your_pass'
 
 # Uncomment and change if you want setup scripts to be pulled
 # from a different repo than github.com/marcone/teslausb
-# export REPO=marcone
+export REPO=THX723
 
 # Uncomment and change if you want a different branch than main-dev
 # export BRANCH=main-dev

--- a/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
+++ b/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
@@ -321,7 +321,7 @@ export WIFIPASS='your_pass'
 
 # Uncomment and change if you want setup scripts to be pulled
 # from a different repo than github.com/marcone/teslausb
-export REPO=THX723
+# export REPO=marcone
 
 # Uncomment and change if you want a different branch than main-dev
 # export BRANCH=main-dev

--- a/run/awake_start
+++ b/run/awake_start
@@ -14,7 +14,6 @@ function ping {
     then
       if /root/bin/tesla_api.py streaming_ping
       then
-        log "Contact car every 90s using Tesla API to keep it awake."
         sleep 90
       else
         log "Failed to contact car using Tesla API, retrying in 5s..."
@@ -28,7 +27,6 @@ function ping {
       if [[ $(curl -s -H "Authorization: Bearer $TESLAFI_API_TOKEN" "https://www.teslafi.com/feed.php?command=wake") = "Wake command received" ]]
       then
         # TeslaFi's default sleep timer is 15min (900s). No need to contact too often to prevent API lockout (max 3 calls/min).
-        log "Contact car every 10min using TeslaFi API to keep it awake."
         sleep 600
       else
         log "Failed to contact car using TeslaFi API, retrying in 90s..."

--- a/run/awake_start
+++ b/run/awake_start
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-if ( [ ! -x /root/bin/tesla_api.py ] || [ ! -s /mutable/cache.json ] ) && [[ ( ! -n "${TESLAFI_API_TOKEN:+x}" ) ]]
+if [[ ( ( ! -x /root/bin/tesla_api.py) || ( ! -s /mutable/cache.json ) ) && ( -z "${TESLAFI_API_TOKEN:+x}" ) ]]
 then
   log "Not keeping car awake."
   exit

--- a/run/awake_start
+++ b/run/awake_start
@@ -1,21 +1,40 @@
 #!/bin/bash -eu
 
-if [ ! -x /root/bin/tesla_api.py ] || [ ! -s /mutable/cache.json ]
+if ( [ ! -x /root/bin/tesla_api.py ] || [ ! -s /mutable/cache.json ] ) && [[ ( ! -n "${TESLAFI_API_TOKEN:+x}" ) ]]
 then
-  log "not keeping car awake."
+  log "Not keeping car awake."
   exit
 fi
 
 function ping {
   while true
   do
-    if /root/bin/tesla_api.py streaming_ping
+    if [[ ( -n "${TESLA_REFRESH_TOKEN:+x}" ) ]]
+    # Use Tesla API to keep car awake
     then
-      sleep 90
-    else
-      log "failed to contact car, retrying"
-      sleep 5
+      if /root/bin/tesla_api.py streaming_ping
+      then
+        log "Contact car every 90s using Tesla API to keep it awake."
+        sleep 90
+      else
+        log "Failed to contact car using Tesla API, retrying in 5s..."
+        sleep 5
+      fi
     fi
+
+    if [[ ( -n "${TESLAFI_API_TOKEN:+x}" ) ]]
+    # Use TeslaFi API to keep car awake
+    then
+      if [[ $(curl -s -H "Authorization: Bearer $TESLAFI_API_TOKEN" "https://www.teslafi.com/feed.php?command=wake") = "Wake command received" ]]
+      then
+        # TeslaFi's default sleep timer is 15min (900s). No need to contact too often to prevent API lockout (max 3 calls/min).
+        log "Contact car every 10min using TeslaFi API to keep it awake."
+        sleep 600
+      else
+        log "Failed to contact car using TeslaFi API, retrying in 90s..."
+        sleep 90
+      fi
+    fi    
   done
 }
 
@@ -38,4 +57,3 @@ case "${TESLA_WAKE_MODE:-stream}" in
     log "Unknown TESLA_WAKE_MODE: ${TESLA_WAKE_MODE}."
     ;;
 esac
-

--- a/run/awake_stop
+++ b/run/awake_stop
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-if ( [ ! -x /root/bin/tesla_api.py ] || [ ! -s /mutable/cache.json ] ) && [[ ( ! -n "${TESLAFI_API_TOKEN:+x}" ) ]]
+if [[ ( ( ! -x /root/bin/tesla_api.py) || ( ! -s /mutable/cache.json ) ) && ( -z "${TESLAFI_API_TOKEN:+x}" ) ]]
 then
   exit
 fi

--- a/run/awake_stop
+++ b/run/awake_stop
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-if [ ! -x /root/bin/tesla_api.py ] || [ ! -s /mutable/cache.json ]
+if ( [ ! -x /root/bin/tesla_api.py ] || [ ! -s /mutable/cache.json ] ) && [[ ( ! -n "${TESLAFI_API_TOKEN:+x}" ) ]]
 then
   exit
 fi
@@ -15,8 +15,7 @@ fi
 
 if [ -e /tmp/keep_awake_task_pid ]
 then
-  log "Stopping wake background task."
+  log "Stopping wake car background task."
   kill "$(cat /tmp/keep_awake_task_pid)" || true
   rm -f /tmp/keep_awake_task_pid
 fi
-

--- a/setup/pi/configure.sh
+++ b/setup/pi/configure.sh
@@ -203,7 +203,26 @@ function install_and_configure_tesla_api () {
       log_progress "tesla_api.py setup failed"
     fi
   else
-    log_progress "Skipping tesla_api.py install because no credentials were provided"
+    log_progress "Skipping tesla_api.py install because no Tesla credentials were provided."
+  fi
+}
+
+function check_teslafi_api () {
+  if [[ ( -n "${TESLAFI_API_TOKEN:+x}" ) ]]
+  then
+    if [[ ( -n "${TESLA_REFRESH_TOKEN:+x}" ) ]]
+    then
+      log_progress "STOP: You're trying to setup Tesla and TeslaFi APIs at the same time."
+      log_progress "Only 1 can be enabled at a time."
+    elif [[ ( -n "${TESLA_WAKE_MODE:+x}" ) ]]    
+    then
+      log_progress "STOP: You've setup for TeslaFi API, yet you've specified a parameter for Tesla API."
+      log_progress "Please comment out TESLA_WAKE_MODE."   
+    else
+      log_progress "TeslaFi API enabled." 
+    fi
+  else
+    log_progress "TeslaFi API not enabled because no TeslaFi credential was provided."
   fi
 }
 
@@ -588,6 +607,7 @@ fi
 
 mkdir -p /root/bin
 
+check_teslafi_api
 check_and_configure_pushover
 check_and_configure_gotify
 check_and_configure_ifttt

--- a/setup/pi/envsetup.sh
+++ b/setup/pi/envsetup.sh
@@ -57,6 +57,7 @@ function read_setup_variables {
   newnamefor[tesla_email]=TESLA_EMAIL
   newnamefor[tesla_password]=TESLA_PASSWORD
   newnamefor[tesla_vin]=TESLA_VIN
+  newnamefor[teslafi_api_token]=TESLAFI_API_TOKEN
   newnamefor[timezone]=TIME_ZONE
   newnamefor[usb_drive]=DATA_DRIVE
   newnamefor[USB_DRIVE]=DATA_DRIVE

--- a/setup/pi/envsetup.sh
+++ b/setup/pi/envsetup.sh
@@ -57,7 +57,6 @@ function read_setup_variables {
   newnamefor[tesla_email]=TESLA_EMAIL
   newnamefor[tesla_password]=TESLA_PASSWORD
   newnamefor[tesla_vin]=TESLA_VIN
-  newnamefor[teslafi_api_token]=TESLAFI_API_TOKEN
   newnamefor[timezone]=TIME_ZONE
   newnamefor[usb_drive]=DATA_DRIVE
   newnamefor[USB_DRIVE]=DATA_DRIVE


### PR DESCRIPTION
Use TeslaFi API to keep car awake as an alternative to using Tesla API.
Supports configuration checking and logging. Full description and directions are noted in the config.sample