### PR TITLE
TeslaFi API Wake & Sleep Tweaks

### DIFF
--- a/run/awake_start
+++ b/run/awake_start
@@ -22,16 +22,11 @@ function ping {
     fi
 
     if [[ ( -n "${TESLAFI_API_TOKEN:+x}" ) ]]
-    # Use TeslaFi API to keep car awake
+    # Use TeslaFi API to keep car awake.
     then
-      if [[ $(curl -s -H "Authorization: Bearer $TESLAFI_API_TOKEN" "https://www.teslafi.com/feed.php?command=wake") = "Wake command received" ]]
-      then
-        # TeslaFi's default sleep timer is 15min (900s). No need to contact too often to prevent API lockout (max 3 calls/min).
-        sleep 600
-      else
-        log "Failed to contact car using TeslaFi API, retrying in 90s..."
-        sleep 90
-      fi
+      curl -s -H "Authorization: Bearer $TESLAFI_API_TOKEN" "https://www.teslafi.com/feed.php?command=wake_up"
+      # No need to contact TeslaFi too often to prevent API lockout (max 3 calls/min).
+      sleep 600
     fi    
   done
 }

--- a/run/awake_stop
+++ b/run/awake_stop
@@ -18,4 +18,11 @@ then
   log "Stopping wake car background task."
   kill "$(cat /tmp/keep_awake_task_pid)" || true
   rm -f /tmp/keep_awake_task_pid
+
+  # TeslaFi Sleep command suspends its polling for the next 15 minutes (by default) to faciliate car's sleep.
+  if [ -n "${TESLAFI_API_TOKEN:+x}" ]
+  then
+    curl -H "Authorization: Bearer $TESLAFI_API_TOKEN" "https://www.teslafi.com/feed.php?command=sleep"
+    log "also initiated TeslaFi Sleep Mode to give the car a chance to fall asleep." 
+  fi
 fi

--- a/run/awake_stop
+++ b/run/awake_stop
@@ -19,8 +19,8 @@ then
   kill "$(cat /tmp/keep_awake_task_pid)" || true
   rm -f /tmp/keep_awake_task_pid
 
-  # TeslaFi Sleep command suspends its polling for the next 15 minutes (by default) to faciliate car's sleep.
   if [[ ( -n "${TESLAFI_API_TOKEN:+x}" ) ]]
+  # TeslaFi Sleep command suspends its polling for the next 15 minutes (by default) to faciliate car's sleep.
   then
     curl -H "Authorization: Bearer $TESLAFI_API_TOKEN" "https://www.teslafi.com/feed.php?command=sleep"
     log "also initiated TeslaFi Sleep Mode to give the car a chance to fall asleep." 

--- a/run/awake_stop
+++ b/run/awake_stop
@@ -20,7 +20,7 @@ then
   rm -f /tmp/keep_awake_task_pid
 
   # TeslaFi Sleep command suspends its polling for the next 15 minutes (by default) to faciliate car's sleep.
-  if [ -n "${TESLAFI_API_TOKEN:+x}" ]
+  if [[ ( -n "${TESLAFI_API_TOKEN:+x}" ) ]]
   then
     curl -H "Authorization: Bearer $TESLAFI_API_TOKEN" "https://www.teslafi.com/feed.php?command=sleep"
     log "also initiated TeslaFi Sleep Mode to give the car a chance to fall asleep." 


### PR DESCRIPTION
Previous use for passive 'wake' command proved to be not reliable, as sometimes the car may still go to sleep, at least w. latest Tesla firmware. Switching to using an explicit 'wake_up' command. Also added Sleep command to encourage the car to go to sleep sooner upon conclusion of archiving.

Note: Had to remove check for command received status, because the response for 'wake_up' is not a simple string, but a json file. This is more complex to process in bash (I'm not familiar). Will save that for future enhancement.