### PR TITLE
Add support for Raspberry Pi 5

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,13 +1,13 @@
 name: "Bug report"
 description: Create a new report
 body:
-    - type: markdown
-      attributes:
-        value: |
-          **Is this the right place for my bug report?**
-          If you simply have a question, please check the [FAQ](/marcone/teslausb/wiki/FAQ) first, and/or check the [troubleshooting steps](/marcone/teslausb/wiki/Troubleshooting). If those do not answer your question use [Discord](https://discord.gg/b4MHf2x).
-          If you you are reporting a problem with teslausb itself, this is the right place.
-          If the problem is a more general Linux or Raspberry Pi OS problem, then [the Raspberry Pi forums](https://www.raspberrypi.org/forums) may offer some help
+  - type: markdown
+    attributes:
+      value: |
+        **Is this the right place for my bug report?**
+        If you simply have a question, please check the [FAQ](/marcone/teslausb/wiki/FAQ) first, and/or check the [troubleshooting steps](/marcone/teslausb/wiki/Troubleshooting). If those do not answer your question use [Discord](https://discord.gg/b4MHf2x).
+        If you you are reporting a problem with teslausb itself, this is the right place.
+        If the problem is a more general Linux or Raspberry Pi OS problem, then [the Raspberry Pi forums](https://www.raspberrypi.org/forums) may offer some help
 
   - type: textarea
     id: description
@@ -18,22 +18,22 @@ body:
     validations:
       required: true
 
-    - type: dropdown
-      id: devicemodel
-      attributes:
-        label: Device
-        description: What model device are you using?
-        multiple: false
-        options:
-          - Raspberry Pi Zero W
-          - Raspberry Pi Zero 2 W
-          - Raspberry Pi 4
+  - type: dropdown
+    id: devicemodel
+    attributes:
+      label: Device
+      description: What model device are you using?
+      multiple: false
+      options:
+        - Raspberry Pi Zero W
+        - Raspberry Pi Zero 2 W
+        - Raspberry Pi 4
         - Raspberry Pi 5
-          - Radxa Zero
-          - Rock Pi 4C plus
-          - Other
-      validations:
-        required: true
+        - Radxa Zero
+        - Rock Pi 4C plus
+        - Other
+    validations:
+      required: true
 
   - type: dropdown
     id: image

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,13 +1,13 @@
 name: "Bug report"
 description: Create a new report
 body:
-  - type: markdown
-    attributes:
-      value: |
-        **Is this the right place for my bug report?**
-        If you simply have a question, please check the [FAQ](/marcone/teslausb/wiki/FAQ) first, and/or check the [troubleshooting steps](/marcone/teslausb/wiki/Troubleshooting). If those do not answer your question use [Discord](https://discord.gg/b4MHf2x).
-        If you you are reporting a problem with teslausb itself, this is the right place.
-        If the problem is a more general Linux or Raspberry Pi OS problem, then [the Raspberry Pi forums](https://www.raspberrypi.org/forums) may offer some help
+    - type: markdown
+      attributes:
+        value: |
+          **Is this the right place for my bug report?**
+          If you simply have a question, please check the [FAQ](/marcone/teslausb/wiki/FAQ) first, and/or check the [troubleshooting steps](/marcone/teslausb/wiki/Troubleshooting). If those do not answer your question use [Discord](https://discord.gg/b4MHf2x).
+          If you you are reporting a problem with teslausb itself, this is the right place.
+          If the problem is a more general Linux or Raspberry Pi OS problem, then [the Raspberry Pi forums](https://www.raspberrypi.org/forums) may offer some help
 
   - type: textarea
     id: description
@@ -18,21 +18,22 @@ body:
     validations:
       required: true
 
-  - type: dropdown
-    id: devicemodel
-    attributes:
-      label: Device
-      description: What model device are you using?
-      multiple: false
-      options:
-        - Raspberry Pi Zero W
-        - Raspberry Pi Zero 2 W
-        - Raspberry Pi 4
-        - Radxa Zero
-        - Rock Pi 4C plus
-        - Other
-    validations:
-      required: true
+    - type: dropdown
+      id: devicemodel
+      attributes:
+        label: Device
+        description: What model device are you using?
+        multiple: false
+        options:
+          - Raspberry Pi Zero W
+          - Raspberry Pi Zero 2 W
+          - Raspberry Pi 4
+        - Raspberry Pi 5
+          - Radxa Zero
+          - Rock Pi 4C plus
+          - Other
+      validations:
+        required: true
 
   - type: dropdown
     id: image

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Required:
 
 - [A Raspberry Pi or other SBC that supports USB OTG](https://github.com/marcone/teslausb/wiki/Hardware).
 - A Micro SD card, at least 64 GB in size, and an adapter (if necessary) to connect the card to your computer.
-- Cable(s) to connect the SBC to the Tesla (USB A/Micro B cable for the Pi Zero, USB A/Micro C cable for Pi 4, USB A/C cable for Pi 5, other SBCs vary)
+- Cable(s) to connect the SBC to the Tesla (USB A/Micro B cable for the Pi Zero, USB A/C cable for the Pi 4 and 5, other SBCs vary)
 
 Optional:
 

--- a/README.md
+++ b/README.md
@@ -10,12 +10,6 @@ Raspberry Pi and other [SBCs](## "Single Board Computers") can emulate a USB dri
 - serve up a web UI to view or download the recordings
 - retain more than one hour of RecentClips (assuming large enough storage)
 
-- automatically copy the recordings to an archive server when you get home
-- hold both dashcam recordings and music files
-- automatically repair filesystem corruption produced by the Tesla's current failure to properly dismount the USB drives before cutting power to the USB ports
-- serve up a web UI to view or download the recordings
-- retain more than one hour of RecentClips (assuming large enough storage)
-
 This video (not mine) has a nice overview of teslausb and how to install it:
 
 [![teslausb intro and installation](http://img.youtube.com/vi/ETs6r1vKTO8/0.jpg)](http://www.youtube.com/watch?v=ETs6r1vKTO8 "teslausb intro and installation")

--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ Raspberry Pi and other [SBCs](## "Single Board Computers") can emulate a USB dri
 - serve up a web UI to view or download the recordings
 - retain more than one hour of RecentClips (assuming large enough storage)
 
+- automatically copy the recordings to an archive server when you get home
+- hold both dashcam recordings and music files
+- automatically repair filesystem corruption produced by the Tesla's current failure to properly dismount the USB drives before cutting power to the USB ports
+- serve up a web UI to view or download the recordings
+- retain more than one hour of RecentClips (assuming large enough storage)
+
 This video (not mine) has a nice overview of teslausb and how to install it:
 
 [![teslausb intro and installation](http://img.youtube.com/vi/ETs6r1vKTO8/0.jpg)](http://www.youtube.com/watch?v=ETs6r1vKTO8 "teslausb intro and installation")
@@ -29,7 +35,7 @@ Required:
 
 - [A Raspberry Pi or other SBC that supports USB OTG](https://github.com/marcone/teslausb/wiki/Hardware).
 - A Micro SD card, at least 64 GB in size, and an adapter (if necessary) to connect the card to your computer.
-- Cable(s) to connect the SBC to the Tesla (USB A/Micro B cable for the Pi Zero, USB A/Micro C cable for Pi 4, other SBCs vary)
+- Cable(s) to connect the SBC to the Tesla (USB A/Micro B cable for the Pi Zero, USB A/Micro C cable for Pi 4, USB A/C cable for Pi 5, other SBCs vary)
 
 Optional:
 

--- a/run/enable_gadget.sh
+++ b/run/enable_gadget.sh
@@ -38,15 +38,17 @@ echo TeslaUSB > "$gadget_root/strings/$lang/manufacturer"
 echo "TeslaUSB Composite Gadget" > "$gadget_root/strings/$lang/product"
 echo "TeslaUSB Config" > "$gadget_root/configs/$cfg.1/strings/$lang/configuration"
 
-# A bare Raspberry Pi 4 can peak at at over 700 mA during boot, but idles around
-# 450 mA, while a Raspberry Pi 4 with a USB drive can peak at over 1 A during boot
-# and idle around 550 mA.
+# A bare Raspberry Pi 4 or 5 can peak at at over 700 mA during boot, but idles around
+# 450 mA or 540 mA respectively, while that Pi with a USB drive can peak at over 1 A 
+# during boot and idle around 550 mA or 600 mA respectively.
 # A Raspberry Pi Zero 2 W can peak at over 300 mA during boot, and has an idle power
 # use of about 100 mA.
 # A Raspberry Pi Zero W can peak up to 220 mA during boot, and has an idle power
 # use of about 80 mA.
-# The largest power demand the gadget can report is 500 mA.
-if isPi4
+if isPi5
+then
+  echo 600 > "$gadget_root/configs/$cfg.1/MaxPower"
+elif isPi4
 then
   echo 500 > "$gadget_root/configs/$cfg.1/MaxPower"
 elif isPi2

--- a/run/enable_gadget.sh
+++ b/run/enable_gadget.sh
@@ -38,13 +38,9 @@ echo TeslaUSB > "$gadget_root/strings/$lang/manufacturer"
 echo "TeslaUSB Composite Gadget" > "$gadget_root/strings/$lang/product"
 echo "TeslaUSB Config" > "$gadget_root/configs/$cfg.1/strings/$lang/configuration"
 
-# A bare Raspberry Pi 4 or 5 can peak at at over 700 mA during boot, but idles around
-# 450 mA or 540 mA respectively, while that Pi with a USB drive can peak at over 1 A 
-# during boot and idle around 550 mA or 600 mA respectively.
-# A Raspberry Pi Zero 2 W can peak at over 300 mA during boot, and has an idle power
-# use of about 100 mA.
-# A Raspberry Pi Zero W can peak up to 220 mA during boot, and has an idle power
-# use of about 80 mA.
+# A bare Raspberry Pi 4 or 5 can peak at at over 1 A during boot, but idles around 500 mA.
+# A Raspberry Pi Zero 2 W can peak at over 300 mA during boot, but idles around 100 mA.
+# A Raspberry Pi Zero W can peak up to 220 mA during boot, but idles around 80 mA.
 if isPi5
 then
   echo 600 > "$gadget_root/configs/$cfg.1/MaxPower"

--- a/setup/pi/envsetup.sh
+++ b/setup/pi/envsetup.sh
@@ -137,6 +137,11 @@ function isRaspberryPi {
   grep -q "Raspberry Pi" /sys/firmware/devicetree/base/model
 }
 
+function isPi5 {
+  grep -q "Raspberry Pi 5" /sys/firmware/devicetree/base/model
+}
+export -f isPi5
+
 function isPi4 {
   grep -q "Raspberry Pi 4" /sys/firmware/devicetree/base/model
 }

--- a/setup/pi/setup-teslausb
+++ b/setup/pi/setup-teslausb
@@ -179,7 +179,7 @@ function headless_setup_mark_setup_success () {
 function flash () {
   local ON=0
   local OFF=1
-  if isPi4
+  if isPi4 || isPi5
   then
     ON=1
     OFF=0
@@ -579,7 +579,7 @@ function diagnose {
       echo "archive method: ${ARCHIVE_SYSTEM:-unset}"
     fi
 
-    if [[ "$DATA_DRIVE" != "" ]] && isPi4
+    if [[ "$DATA_DRIVE" != "" ]] && (isPi4 || isPi5)
     then
       echo "DATA_DRIVE=$DATA_DRIVE: consider booting from USB instead."
     fi

--- a/setup/pi/verify-configuration.sh
+++ b/setup/pi/verify-configuration.sh
@@ -26,8 +26,12 @@ function check_supported_hardware () {
   then
     return
   fi
+  if grep -q 'Raspberry Pi 5' /sys/firmware/devicetree/base/model
+  then
+    return
+  fi
   setup_progress "STOP: unsupported hardware: '$(cat /sys/firmware/devicetree/base/model)'"
-  setup_progress "(only Pi Zero W and Pi 4 have the necessary hardware to run teslausb)"
+  setup_progress "(only Pi Zero W, Pi 4, and Pi 5 have the necessary hardware to run teslausb)"
   exit 1
 }
 


### PR DESCRIPTION
Begins support for Pi 5 that has essentially all the capabilities of Pi 4 and more. USB gadget support isn't quite ready on the PI OS based on Bookworm (that's needed for the 5) per https://github.com/raspberrypi/bookworm-feedback/issues/77 so this is waiting on some firmware updates before it can actually be used and tested, but thought I'd push an initial update for review.

There's a number of whitespace and Markdown formatting changes my editor caught that are also included.