### PR TITLE
Suppress UX courtesy reminders on non-interactive shells

### DIFF
--- a/setup/pi/setup-teslausb
+++ b/setup/pi/setup-teslausb
@@ -918,13 +918,14 @@ sed -i '/source \/root\/bin\/setup-teslausb/d' /root/.bashrc
 if ! grep -q TESLAUSB_TIP1 /root/.bashrc
 then
   cat >> /root/.bashrc <<- EOC
-  if [ -n "\$PS1" ]; then
-	cat << TESLAUSB_TIP1
-	Run 'bin/setup-teslausb upgrade' to update to the latest version of teslausb,
-	or run 'bin/remountfs_rw' to allow writing to the root partition.
+	if [ -n "\$PS1" ]
+	then
+		cat << TESLAUSB_TIP1
+		Run 'bin/setup-teslausb upgrade' to update to the latest version of teslausb,
+		or run 'bin/remountfs_rw' to allow writing to the root partition.
 
-	TESLAUSB_TIP1
-  fi
+		TESLAUSB_TIP1
+	fi
 	EOC
 fi
 
@@ -934,12 +935,12 @@ then
   if ! grep -q TESLAUSB_TIP1 "/home/$DEFUSER/.bashrc"
   then
     cat >> "/home/$DEFUSER/.bashrc" <<- EOC
-  if [ -n "\$PS1" ]; then
-	cat << TESLAUSB_TIP1
-	Run 'sudo -i' if you need to make changes.
+	if [ -n "\$PS1" ]; then
+		cat << TESLAUSB_TIP1
+		Run 'sudo -i' if you need to make changes.
 
-	TESLAUSB_TIP1
-  fi
+		TESLAUSB_TIP1
+	fi
 	EOC
   fi
 fi

--- a/setup/pi/setup-teslausb
+++ b/setup/pi/setup-teslausb
@@ -918,11 +918,13 @@ sed -i '/source \/root\/bin\/setup-teslausb/d' /root/.bashrc
 if ! grep -q TESLAUSB_TIP1 /root/.bashrc
 then
   cat >> /root/.bashrc <<- EOC
+  if [ -n "\$PS1" ]; then
 	cat << TESLAUSB_TIP1
 	Run 'bin/setup-teslausb upgrade' to update to the latest version of teslausb,
 	or run 'bin/remountfs_rw' to allow writing to the root partition.
 
 	TESLAUSB_TIP1
+  fi
 	EOC
 fi
 
@@ -932,10 +934,12 @@ then
   if ! grep -q TESLAUSB_TIP1 "/home/$DEFUSER/.bashrc"
   then
     cat >> "/home/$DEFUSER/.bashrc" <<- EOC
+  if [ -n "\$PS1" ]; then
 	cat << TESLAUSB_TIP1
 	Run 'sudo -i' if you need to make changes.
 
 	TESLAUSB_TIP1
+  fi
 	EOC
   fi
 fi

--- a/setup/pi/setup-teslausb
+++ b/setup/pi/setup-teslausb
@@ -918,8 +918,7 @@ sed -i '/source \/root\/bin\/setup-teslausb/d' /root/.bashrc
 if ! grep -q TESLAUSB_TIP1 /root/.bashrc
 then
   cat >> /root/.bashrc <<- EOC
-	if [ -n "\$PS1" ]
-	then
+	if [ -n "\$PS1" ]; then
 		cat << TESLAUSB_TIP1
 		Run 'bin/setup-teslausb upgrade' to update to the latest version of teslausb,
 		or run 'bin/remountfs_rw' to allow writing to the root partition.


### PR DESCRIPTION
I was having issues SCPing and rsyncing to TeslaUSB from another machine due to the UX courtesy reminders. I found these changes suppress the messages in non-interactive shells, resolving the issue.