### PR TITLE
Fix auth_basic to explicitly enable if user requested web auth

### DIFF
--- a/setup/pi/configure-web.sh
+++ b/setup/pi/configure-web.sh
@@ -34,6 +34,7 @@ if [ -n "${WEB_USERNAME:-}" ] && [ -n "${WEB_PASSWORD:-}" ]
 then
   apt-get -y --force-yes install apache2-utils
   htpasswd -bc /etc/nginx/.htpasswd "$WEB_USERNAME" "$WEB_PASSWORD"
+  sed -i 's/auth_basic off/auth_basic "Restricted Content"/' /etc/nginx/sites-available/teslausb.nginx
 else
   sed -i 's/auth_basic "Restricted Content"/auth_basic off/' /etc/nginx/sites-available/teslausb.nginx
 fi


### PR DESCRIPTION
- A previous [commit](https://github.com/marcone/teslausb/commit/2f40f6089fb165eab2280acdb89fc0a9d055899a) removed the default auth_basic enable in `teslausb.nginx` which broke the configuration for web auth. 
- The fix is to explicitly enable web auth on `teslausb.nginx` from the `configure-web.sh` script.