### PR TITLE
Error handling for invalid directories

### DIFF
--- a/teslausb-www/html/index.html
+++ b/teslausb-www/html/index.html
@@ -2591,9 +2591,13 @@ readfile({url:'cgi-bin/videolist.sh', callback:function(value) {
       }
       videos[i][c].initialize();
 
-      var newelem = makeDropdownItem(i, c, videos[i][c] == newestsequence);
-      if (newelem != undefined) {
-        d.appendChild(newelem);
+      try {
+        var newelem = makeDropdownItem(i, c, videos[i][c] == newestsequence);
+        if (newelem != undefined) {
+          d.appendChild(newelem);
+        }
+      } catch (error) {
+        console.error(`Error parsing ${i}/${c}: ${error}`);
       }
     }
     if (localStorageGet("eventorder") == "newest") {


### PR DESCRIPTION
I'm not sure how, but my RecentClips directory ended up with a subdirectory called `event.mp4`. TeslaUSB's web UI throws an error when it tries to parse the directory name for the dropdown menus. The error breaks loading for the rest of the menus and other parts of the UI such as the Archiveloop log viewer and the Tools page. This PR catches the error and logs it to the console so it does not affect the rest of the UI.