### PR TITLE
Suppress ethtool unprivileged errors in fcgiwrap systemctl output

### DIFF
--- a/teslausb-www/html/cgi-bin/status.sh
+++ b/teslausb-www/html/cgi-bin/status.sh
@@ -38,7 +38,7 @@ ethdev=$(find /sys/class/net/ -type l \( -name 'eth*' -o -name 'en*' \) -printf 
 if [ -n "$ethdev" ]
 then
   read -r _ ether_ip _ < <(ifconfig "$ethdev" | grep "inet ")
-  IFS=" :" read -r _ ether_speed < <(ethtool "$ethdev" | grep Speed)
+  IFS=" :" read -r _ ether_speed < <(ethtool "$ethdev" 2>&1 | grep Speed)
 else
   ether_ip=
   ether_speed=


### PR DESCRIPTION
There are `status.sh` script errors in the fcgiwrap output:
```
orangepizero3:~# systemctl status fcgiwrap
● fcgiwrap.service - Simple CGI Server
     Loaded: loaded (/lib/systemd/system/fcgiwrap.service; indirect; preset: enabled)
     Active: active (running) since Thu 2024-09-26 00:10:28 PDT; 58min ago
TriggeredBy: ● fcgiwrap.socket
   Main PID: 7223 (fcgiwrap)
      Tasks: 5 (limit: 1534)
     Memory: 1.3M
        CPU: 3min 9.316s
     CGroup: /system.slice/fcgiwrap.service
             ├─7223 /usr/sbin/fcgiwrap "-c 4 -f"
             ├─7224 /usr/sbin/fcgiwrap "-c 4 -f"
             ├─7225 /usr/sbin/fcgiwrap "-c 4 -f"
             ├─7226 /usr/sbin/fcgiwrap "-c 4 -f"
             └─7227 /usr/sbin/fcgiwrap "-c 4 -f"

Sep 26 00:57:57 teslausb-bozjaka-orangepizero3 fcgiwrap[7227]: netlink error: Operation not permitted
Sep 26 00:57:58 teslausb-bozjaka-orangepizero3 fcgiwrap[7226]: netlink error: Operation not permitted
Sep 26 00:57:59 teslausb-bozjaka-orangepizero3 fcgiwrap[7224]: netlink error: Operation not permitted
Sep 26 00:58:00 teslausb-bozjaka-orangepizero3 fcgiwrap[7225]: netlink error: Operation not permitted
Sep 26 00:58:01 teslausb-bozjaka-orangepizero3 fcgiwrap[7227]: netlink error: Operation not permitted
Sep 26 00:58:02 teslausb-bozjaka-orangepizero3 fcgiwrap[7225]: netlink error: Operation not permitted
Sep 26 00:58:07 teslausb-bozjaka-orangepizero3 fcgiwrap[7226]: netlink error: Operation not permitted
Sep 26 00:58:12 teslausb-bozjaka-orangepizero3 fcgiwrap[7224]: netlink error: Operation not permitted
Sep 26 00:58:17 teslausb-bozjaka-orangepizero3 fcgiwrap[7225]: netlink error: Operation not permitted
Sep 26 00:58:22 teslausb-bozjaka-orangepizero3 fcgiwrap[7227]: netlink error: Operation not permitted
root@teslausb-bozjaka-orangepizero3:~#
```

caused by unprivileged (www-data) user `ethtool` output refresh, eg:
```
orangepizero3:~# sudo -u www-data ethtool end0
Settings for end0:
        Supported ports: [ TP    MII ]
        Supported link modes:   10baseT/Half 10baseT/Full
                                100baseT/Half 100baseT/Full
                                1000baseT/Full
        Supported pause frame use: Symmetric Receive-only
        Supports auto-negotiation: Yes
        Supported FEC modes: Not reported
        Advertised link modes:  10baseT/Half 10baseT/Full
                                100baseT/Half 100baseT/Full
                                1000baseT/Full
        Advertised pause frame use: Symmetric Receive-only
        Advertised auto-negotiation: Yes
        Advertised FEC modes: Not reported
        Speed: Unknown!
        Duplex: Unknown! (255)
        Auto-negotiation: on
        master-slave cfg: preferred slave
        master-slave status: unknown
        Port: Twisted Pair
        PHYAD: 1
        Transceiver: external
        MDI-X: Unknown
netlink error: Operation not permitted
        Current message level: 0x0000003f (63)
                               drv probe link timer ifdown ifup
        Link detected: no
```

The error is informational only, cluttering systemctl output and could be safely ignored