### PR TITLE
Added check for installed overlayroot

### DIFF
--- a/run/remountfs_rw
+++ b/run/remountfs_rw
@@ -1,11 +1,17 @@
 #!/bin/bash
 
 echo "Making root partition writeable"
-mount / -o remount,rw
+# overlayroot check
+if egrep "overlayroot" /proc/mounts >/dev/null 2>&1; then
+  overlayroot-chroot
+  echo "Done. Make any changes needed, enter exit and reboot the device when ready."
+else
+  mount / -o remount,rw
 
-if findmnt /teslausb > /dev/null
-then
-  echo "Making boot/firmware partition writeable"
-  mount /teslausb -o remount,rw
+  if findmnt /teslausb > /dev/null
+  then
+    echo "Making boot/firmware partition writeable"
+    mount /teslausb -o remount,rw
+  fi
+  echo "Done. Make any changes needed, and reboot the Pi when ready."
 fi
-echo "Done. Make any changes needed, and reboot the Pi when ready."

--- a/setup/pi/make-root-fs-readonly.sh
+++ b/setup/pi/make-root-fs-readonly.sh
@@ -11,6 +11,12 @@ function log_progress () {
   echo "make-root-fs-readonly: $1"
 }
 
+# check for overlayroot existence
+if [ -x "$(command -v overlayroot-chroot)" ]
+  log_progress "Skipping - overlayroot is installed"
+  exit 0
+fi
+
 if [ "${SKIP_READONLY:-false}" = "true" ]
 then
   log_progress "Skipping"

--- a/setup/pi/make-root-fs-readonly.sh
+++ b/setup/pi/make-root-fs-readonly.sh
@@ -13,6 +13,7 @@ function log_progress () {
 
 # check for overlayroot existence
 if [ -x "$(command -v overlayroot-chroot)" ]
+then
   log_progress "Skipping - overlayroot is installed"
   exit 0
 fi


### PR DESCRIPTION
On DietPi the /etc/fstab file is automatically generated by a script, so the read-only mounting code of teslausb does not work correctly. As an alternative, I installed overlayroot and that works fine. This PR adds support for overlayroot to teslausb.

Setup overlayroot:

```shell
apt install overlayroot busybox-static 
echo 'overlayroot=tmpfs' >> /etc/overlayroot.local.conf
reboot
```
