### PR TITLE
cellular: attempt sync right after each snapshot

### DIFF
--- a/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
+++ b/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
@@ -16,6 +16,10 @@
 export SSID='your_ssid'
 export WIFIPASS='your_pass'
 
+# Cellular Connection Quality-of-Life
+# 1. If using a cellular connection, turn on the following flag to have TeslaUSB attempt sync right after each snapshot.
+# export ARCHIVE_SYNC_AFTER_SNAPSHOP=true
+
 # Variables for CIFS (Windows/Mac file sharing) archiving.
 # If you want to use rsync or rclone, delete or comment out this section
 # and uncomment the rsync or rclone section below.

--- a/run/archiveloop
+++ b/run/archiveloop
@@ -669,6 +669,7 @@ function has_cam_disk () {
 }
 
 function archive_clips () {
+  touch /mutable/ARCHIVING_CLIPS
   log "Archiving..."
 
   if ! /root/bin/connect-archive.sh
@@ -701,6 +702,7 @@ function archive_clips () {
   fi
 
   /root/bin/disconnect-archive.sh
+  rm /mutable/ARCHIVING_CLIPS
 }
 
 function slowblink () {
@@ -747,6 +749,11 @@ function snapshotloop {
     sleep "${SNAPSHOT_INTERVAL:-3480}"
     /root/bin/waitforidle || true
     /root/bin/make_snapshot.sh
+
+    if [ ! -e /mutable/ARCHIVING_CLIPS ] && [ "${ARCHIVE_SYNC_AFTER_SNAPSHOP:-false}" = "true" ]
+    then
+      archive_clips
+    fi
   done
 }
 

--- a/run/archiveloop
+++ b/run/archiveloop
@@ -669,40 +669,43 @@ function has_cam_disk () {
 }
 
 function archive_clips () {
-  touch /mutable/ARCHIVING_CLIPS
-  log "Archiving..."
-
-  if ! /root/bin/connect-archive.sh
-  then
-    log "Couldn't connect archive, skipping archive step"
-    return
-  fi
-
-  if ! has_cam_disk
-  then
-    log "Skipping archiving (no cam disk)"
-  elif archive_teslacam_clips
-  then
-    log "Finished archiving."
-  else
-    log "Archiving failed."
-  fi
-
-  if timeout 5 [ -d "$MUSIC_ARCHIVE_MOUNT" -a -d "$MUSIC_MOUNT" ]
-  then
-    log "Copying music..."
-    if copy_music_files
+  if [ ! -e /mutable/ARCHIVING_CLIPS ]
+  then 
+    touch /mutable/ARCHIVING_CLIPS
+    log "Archiving..."
+  
+    if ! /root/bin/connect-archive.sh
     then
-      log "Finished copying music."
-    else
-      log "Copying music failed."
+      log "Couldn't connect archive, skipping archive step"
+      return
     fi
-  else
-    log "Music archive not configured or unreachable"
+  
+    if ! has_cam_disk
+    then
+      log "Skipping archiving (no cam disk)"
+    elif archive_teslacam_clips
+    then
+      log "Finished archiving."
+    else
+      log "Archiving failed."
+    fi
+  
+    if timeout 5 [ -d "$MUSIC_ARCHIVE_MOUNT" -a -d "$MUSIC_MOUNT" ]
+    then
+      log "Copying music..."
+      if copy_music_files
+      then
+        log "Finished copying music."
+      else
+        log "Copying music failed."
+      fi
+    else
+      log "Music archive not configured or unreachable"
+    fi
+  
+    /root/bin/disconnect-archive.sh
+    rm /mutable/ARCHIVING_CLIPS
   fi
-
-  /root/bin/disconnect-archive.sh
-  rm /mutable/ARCHIVING_CLIPS
 }
 
 function slowblink () {
@@ -750,9 +753,9 @@ function snapshotloop {
     /root/bin/waitforidle || true
     /root/bin/make_snapshot.sh
 
-    if [ ! -e /mutable/ARCHIVING_CLIPS ] && [ "${ARCHIVE_SYNC_AFTER_SNAPSHOP:-false}" = "true" ]
+    if [ "${ARCHIVE_SYNC_AFTER_SNAPSHOP:-false}" = "true" ]
     then
-      archive_clips
+      archive_clips &
     fi
   done
 }


### PR DESCRIPTION
Function `archive_clips` is expected to be run async and thus will put a lock file in `/mutable` when it's running. If the env var flag `ARCHIVE_SYNC_AFTER_SNAPSHOP` is set, `archive_clips` will be called each time snapshot is completed.

Do you think this is a good idea? Sorry that I am inexperienced working with bash scripts and not sure if this lock file thing is good practice.