### PR TITLE
TeslaFi awake_start and awake_stop now function correctly

### DIFF
--- a/run/awake_start
+++ b/run/awake_start
@@ -1,94 +1,53 @@
 #!/bin/bash -eu
 
-# Function to set Sentry Mode via TeslaFI
+# Function to enable Sentry Mode via TeslaFi API
 function set_sentry_mode {
   local sentry_mode=$1
-  local response
-  response=$(curl -s -w "%{http_code}" -H "Authorization: Bearer $TESLAFI_API_TOKEN" "https://www.teslafi.com/feed.php?command=set_sentry_mode&sentryMode=$sentry_mode")
-  local status_code="${response: -3}"
-  if [[ "$status_code" -ne 200 ]]; then
-    log "Error setting Sentry Mode via TeslaFi. Status code: ${status_code}. Please check your TESLAFI_API_TOKEN."
-    exit 1
+  if [ -n "${TESLAFI_API_TOKEN:+x}" ]; then
+    response=$(curl -s -w "%{http_code}" -H "Authorization: Bearer $TESLAFI_API_TOKEN" \
+      "https://www.teslafi.com/feed.php?command=set_sentry_mode&sentryMode=$sentry_mode")
+    status_code="${response: -3}"
+    if [[ "$status_code" -ne 200 ]]; then
+      log "Error setting Sentry Mode via TeslaFi. Status code: ${status_code}."
+    fi
+  else
+    log "ERROR: No TeslaFi API token available, unable to control Sentry Mode."
   fi
 }
 
-if [[ ( ! -x /root/bin/tesla_api.py || ! -s /mutable/cache.json ) && -z "${TESLAFI_API_TOKEN:+x}" && -z "${TESSIE_API_TOKEN:+x}" ]]
-then
-  log "Not keeping car awake."
-  exit
+# Ensure we have TeslaFi credentials
+if [[ -z "${TESLAFI_API_TOKEN:+x}" ]]; then
+  log "No TeslaFi API token available. Cannot check Sentry Mode status."
+  exit 1
 fi
 
-function ping {
-  while true
-  do
-    if [[ -n "${TESLA_REFRESH_TOKEN:+x}" ]]; then
-      # Use Tesla API to keep car awake
-      if timeout 10 /root/bin/tesla_api.py streaming_ping; then
-        sleep 90
-      else
-        log "Failed to contact car using Tesla API, retrying in 5s..."
-        sleep 5
-      fi
-    fi
+# Get current Sentry Mode status from TeslaFi (using carState)
+is_sentry_mode_enabled=$(curl -s -H "Authorization: Bearer $TESLAFI_API_TOKEN" \
+  "https://www.teslafi.com/feed.php?command=" | jq -r '.carState')
 
-    if [[ -n "${TESLAFI_API_TOKEN:+x}" ]]; then
-      # Use TeslaFi API to keep car awake.
-      curl -s -H "Authorization: Bearer $TESLAFI_API_TOKEN" "https://www.teslafi.com/feed.php?command=wake_up"
-      # No need to contact TeslaFi too often to prevent API lockout (max 3 calls/min).
-      sleep 600
-    fi
+# Convert to true/false
+if [[ "$is_sentry_mode_enabled" == "Sentry" ]]; then
+  is_sentry_mode_enabled="true"
+else
+  is_sentry_mode_enabled="false"
+fi
 
-    if [[ -n "${TESSIE_API_TOKEN:+x}" ]]; then
-      # Use Tessie API to keep car awake
-      http_response=$(curl -s -w "%{http_code}" \
-          -H "Authorization: Bearer $TESSIE_API_TOKEN" \
-          -H "Accept: application/json" \
-          -H "User-Agent: github.com/marcone/teslausb" \
-          "https://api.tessie.com/$TESSIE_VIN/wake")
-  
-      # Extract HTTP status code
-      http_status="${http_response: -3}"
-      
-      # Extract response body (excluding status code)
-      response_body="${http_response:0:${#http_response}-3}"
-      
-      # Check if HTTP status code is not 200 (OK)
-      if [ "$http_status" != "200" ]; then
-          # Log an error
-          log "Failed to wake car with Tessie API. Check your TESSIE_API_TOKEN and TESSIE_VIN are set correctly. If they are, your car may not have a good connection. Retrying in 1 minute..."
-          sleep 60
-      else
-          # Check if the response is in JSON format
-          if ! jq -e . >/dev/null 2>&1 <<< "$response_body"; then
-              log "Failed to wake car with Tessie API. Retrying in 1 minute. Response data: $response_body"
-              sleep 60
-          else
-              # Parse JSON and check if "result" is true
-              result=$(jq -r '.result' <<< "$response_body")
-              if [[ "$result" != "true" ]]; then
-                  log "Failed to wake car with Tessie API. Retrying in 1 minute. Response data: $response_body"
-                  sleep 60
-              else
-                  # Sleep for 5 minutes on successful wake-up call
-                  sleep 300
-              fi
-          fi
-      fi
-    fi
-  done
-}
-
-# Use TeslaFi to manage Sentry Mode
-is_sentry_mode_enabled=$(/root/bin/tesla_api.py is_sentry_mode_enabled | tr '[:upper:]' '[:lower:]')
-if [ "false" = "${is_sentry_mode_enabled}" ]; then
-  log "Turning on Sentry Mode to keep car awake (via Tesla API)."
-  /root/bin/tesla_api.py enable_sentry_mode &>> "${LOG_FILE}"
+# If Sentry Mode is OFF, enable it via TeslaFi API
+if [ "$is_sentry_mode_enabled" = "false" ]; then
+  log "Sentry Mode is OFF, enabling it via TeslaFi..."
+  set_sentry_mode true
   echo "sentry_enabled" > /tmp/sentry_state
 else
   log "Sentry Mode is already enabled."
   echo "sentry_already_enabled" > /tmp/sentry_state
 fi
 
-# Start the continuous ping process in the background
-ping &
+# Start the background task to keep the car awake (if necessary)
+function ping {
+  while true; do
+    sleep 300  # No need to wake the car, as TeslaFi handles telemetry
+  done
+}
+
+ping &  
 echo $! > /tmp/keep_awake_task_pid

--- a/run/awake_start
+++ b/run/awake_start
@@ -1,6 +1,18 @@
 #!/bin/bash -eu
 
-if [[ ( ( ! -x /root/bin/tesla_api.py) || ( ! -s /mutable/cache.json ) ) && ( -z "${TESLAFI_API_TOKEN:+x}" ) && ( -z "${TESSIE_API_TOKEN:+x}" ) ]]
+# Function to set Sentry Mode via TeslaFI
+function set_sentry_mode {
+  local sentry_mode=$1
+  local response
+  response=$(curl -s -w "%{http_code}" -H "Authorization: Bearer $TESLAFI_API_TOKEN" "https://www.teslafi.com/feed.php?command=set_sentry_mode&sentryMode=$sentry_mode")
+  local status_code="${response: -3}"
+  if [[ "$status_code" -ne 200 ]]; then
+    log "Error setting Sentry Mode via TeslaFi. Status code: ${status_code}. Please check your TESLAFI_API_TOKEN."
+    exit 1
+  fi
+}
+
+if [[ ( ! -x /root/bin/tesla_api.py || ! -s /mutable/cache.json ) && -z "${TESLAFI_API_TOKEN:+x}" && -z "${TESSIE_API_TOKEN:+x}" ]]
 then
   log "Not keeping car awake."
   exit
@@ -9,11 +21,9 @@ fi
 function ping {
   while true
   do
-    if [[ ( -n "${TESLA_REFRESH_TOKEN:+x}" ) ]]
-    # Use Tesla API to keep car awake
-    then
-      if timeout 10 /root/bin/tesla_api.py streaming_ping
-      then
+    if [[ -n "${TESLA_REFRESH_TOKEN:+x}" ]]; then
+      # Use Tesla API to keep car awake
+      if timeout 10 /root/bin/tesla_api.py streaming_ping; then
         sleep 90
       else
         log "Failed to contact car using Tesla API, retrying in 5s..."
@@ -21,74 +31,64 @@ function ping {
       fi
     fi
 
-    if [[ ( -n "${TESLAFI_API_TOKEN:+x}" ) ]]
-    # Use TeslaFi API to keep car awake.
-    then
+    if [[ -n "${TESLAFI_API_TOKEN:+x}" ]]; then
+      # Use TeslaFi API to keep car awake.
       curl -s -H "Authorization: Bearer $TESLAFI_API_TOKEN" "https://www.teslafi.com/feed.php?command=wake_up"
       # No need to contact TeslaFi too often to prevent API lockout (max 3 calls/min).
       sleep 600
     fi
 
-    if [[ -n "${TESSIE_API_TOKEN:+x}" ]]
-    # Use Tessie API to keep car awake
-    then
-        http_response=$(curl -s -w "%{http_code}" \
-            -H "Authorization: Bearer $TESSIE_API_TOKEN" \
-            -H "Accept: application/json" \
-            -H "User-Agent: github.com/marcone/teslausb" \
-            "https://api.tessie.com/$TESSIE_VIN/wake")
-        
-        # Extract HTTP status code
-        http_status="${http_response: -3}"
-        
-        # Extract response body (excluding status code)
-        response_body="${http_response:0:${#http_response}-3}"
-        
-        # Check if HTTP status code is not 200 (OK)
-        if [ "$http_status" != "200" ]
-        then
-            # Log an error
-            log "Failed to wake car with Tessie API. Check your TESSIE_API_TOKEN and TESSIE_VIN are set correctly. If they are, your car may not have a good connection. Retrying in 1 minute..."
-            sleep 60
-        else
-            # Check if the response is in JSON format
-            if ! jq -e . >/dev/null 2>&1 <<<"$response_body"
-            then
-                log "Failed to wake car with Tessie API. Retrying in 1 minute. Response data: $response_body"
-                sleep 60
-            else
-                # Parse JSON and check if "result" is true
-                result=$(jq -r '.result' <<<"$response_body")
-                if [[ "$result" != "true" ]]
-                then
-                    log "Failed to wake car with Tessie API. Retrying in 1 minute. Response data: $response_body"
-                    sleep 60
-                else
-                    # Sleep for 5 minutes on successful wake-up call
-                    sleep 300
-                fi
-            fi
-        fi
+    if [[ -n "${TESSIE_API_TOKEN:+x}" ]]; then
+      # Use Tessie API to keep car awake
+      http_response=$(curl -s -w "%{http_code}" \
+          -H "Authorization: Bearer $TESSIE_API_TOKEN" \
+          -H "Accept: application/json" \
+          -H "User-Agent: github.com/marcone/teslausb" \
+          "https://api.tessie.com/$TESSIE_VIN/wake")
+  
+      # Extract HTTP status code
+      http_status="${http_response: -3}"
+      
+      # Extract response body (excluding status code)
+      response_body="${http_response:0:${#http_response}-3}"
+      
+      # Check if HTTP status code is not 200 (OK)
+      if [ "$http_status" != "200" ]; then
+          # Log an error
+          log "Failed to wake car with Tessie API. Check your TESSIE_API_TOKEN and TESSIE_VIN are set correctly. If they are, your car may not have a good connection. Retrying in 1 minute..."
+          sleep 60
+      else
+          # Check if the response is in JSON format
+          if ! jq -e . >/dev/null 2>&1 <<< "$response_body"; then
+              log "Failed to wake car with Tessie API. Retrying in 1 minute. Response data: $response_body"
+              sleep 60
+          else
+              # Parse JSON and check if "result" is true
+              result=$(jq -r '.result' <<< "$response_body")
+              if [[ "$result" != "true" ]]; then
+                  log "Failed to wake car with Tessie API. Retrying in 1 minute. Response data: $response_body"
+                  sleep 60
+              else
+                  # Sleep for 5 minutes on successful wake-up call
+                  sleep 300
+              fi
+          fi
+      fi
     fi
   done
 }
 
-case "${TESLA_WAKE_MODE:-stream}" in
-  sentry)
-    is_sentry_mode_enabled=$(/root/bin/tesla_api.py is_sentry_mode_enabled | tr '[:upper:]' '[:lower:]')
-    if [ "false" = "${is_sentry_mode_enabled}" ]
-    then
-      log "Temporarily enabling Sentry Mode to keep car awake."
-      touch /tmp/disable_sentry_after_archiving
-      /root/bin/tesla_api.py enable_sentry_mode &>> "${LOG_FILE}"
-    fi
-    ;;
-  stream)
-    log "Starting background task to keep car awake."
-    ping &
-    echo $! > /tmp/keep_awake_task_pid
-    ;;
-  *)
-    log "Unknown TESLA_WAKE_MODE: ${TESLA_WAKE_MODE}."
-    ;;
-esac
+# Use TeslaFi to manage Sentry Mode
+is_sentry_mode_enabled=$(/root/bin/tesla_api.py is_sentry_mode_enabled | tr '[:upper:]' '[:lower:]')
+if [ "false" = "${is_sentry_mode_enabled}" ]; then
+  log "Turning on Sentry Mode to keep car awake (via Tesla API)."
+  /root/bin/tesla_api.py enable_sentry_mode &>> "${LOG_FILE}"
+  echo "sentry_enabled" > /tmp/sentry_state
+else
+  log "Sentry Mode is already enabled."
+  echo "sentry_already_enabled" > /tmp/sentry_state
+fi
+
+# Start the continuous ping process in the background
+ping &
+echo $! > /tmp/keep_awake_task_pid

--- a/run/awake_start
+++ b/run/awake_start
@@ -15,7 +15,7 @@ function set_sentry_mode {
   fi
 }
 
-# Ensure we have TeslaFi credentials
+# Ensure TeslaFi API token is available
 if [[ -z "${TESLAFI_API_TOKEN:+x}" ]]; then
   log "No TeslaFi API token available. Cannot check Sentry Mode status."
   exit 1
@@ -35,19 +35,24 @@ fi
 # If Sentry Mode is OFF, enable it via TeslaFi API
 if [ "$is_sentry_mode_enabled" = "false" ]; then
   log "Sentry Mode is OFF, enabling it via TeslaFi..."
-  set_sentry_mode true
-  echo "sentry_enabled" > /tmp/sentry_state
+  if set_sentry_mode true; then
+    echo "sentry_enabled" > /tmp/sentry_state
+    /root/bin/send-push-message "$NOTIFICATION_TITLE:" "🚗 Sentry Mode enabled via TeslaFi to keep the car awake." start
+  else
+    log "⚠️ Failed to enable Sentry Mode via TeslaFi."
+    /root/bin/send-push-message "$NOTIFICATION_TITLE:" "⚠️ Unable to enable Sentry Mode via TeslaFi. The car may enter sleep mode." start
+  fi
 else
   log "Sentry Mode is already enabled."
   echo "sentry_already_enabled" > /tmp/sentry_state
 fi
 
-# Start the background task to keep the car awake (if necessary)
-function ping {
+# Background process to keep the car awake (only necessary if TeslaFi isn't handling telemetry)
+function keep_awake {
   while true; do
     sleep 300  # No need to wake the car, as TeslaFi handles telemetry
   done
 }
 
-ping &  
+keep_awake &  
 echo $! > /tmp/keep_awake_task_pid

--- a/run/awake_stop
+++ b/run/awake_stop
@@ -1,28 +1,44 @@
 #!/bin/bash -eu
 
-if [[ ( ( ! -x /root/bin/tesla_api.py) || ( ! -s /mutable/cache.json ) ) && ( -z "${TESLAFI_API_TOKEN:+x}" ) && ( -z "${TESSIE_API_TOKEN:+x}" ) ]]
-then
-  exit
+# Function to disable Sentry Mode via TeslaFi API
+function set_sentry_mode {
+  local sentry_mode=$1
+  if [ -n "${TESLAFI_API_TOKEN:+x}" ]; then
+    response=$(curl -s -w "%{http_code}" -H "Authorization: Bearer $TESLAFI_API_TOKEN" \
+      "https://www.teslafi.com/feed.php?command=set_sentry_mode&sentryMode=$sentry_mode")
+    status_code="${response: -3}"
+    if [[ "$status_code" -ne 200 ]]; then
+      log "Error disabling Sentry Mode via TeslaFi. Status code: ${status_code}."
+    fi
+  else
+    log "ERROR: No TeslaFi API token available, unable to control Sentry Mode."
+  fi
+}
+
+# Check the stored Sentry Mode state
+if [ -f /tmp/sentry_state ]; then
+  sentry_state=$(cat /tmp/sentry_state)
+  rm -f /tmp/sentry_state
+
+  if [ "$sentry_state" == "sentry_enabled" ]; then
+    log "Disabling Sentry Mode via TeslaFi..."
+    set_sentry_mode false
+  elif [ "$sentry_state" == "sentry_already_enabled" ]; then
+    log "Sentry Mode was already enabled, leaving it on."
+  else
+    log "Warning: Unknown Sentry Mode state."
+  fi
 fi
 
-# If Sentry Mode was previously disabled, restore it to that state
-if [ -e /tmp/disable_sentry_after_archiving ]
-then
-  log "Restoring Sentry Mode to its previous state (disabled)..."
-  /root/bin/tesla_api.py disable_sentry_mode &>> "${LOG_FILE}"
-  rm -f /tmp/disable_sentry_after_archiving
-fi
-
-if [ -e /tmp/keep_awake_task_pid ]
-then
+# Stop the background keep-awake process if running
+if [ -e /tmp/keep_awake_task_pid ]; then
   log "Stopping wake car background task."
   kill "$(cat /tmp/keep_awake_task_pid)" || true
   rm -f /tmp/keep_awake_task_pid
 
-  if [[ ( -n "${TESLAFI_API_TOKEN:+x}" ) ]]
-  # TeslaFi Sleep command suspends its polling for the next 15 minutes (by default) to faciliate car's sleep.
-  then
-    curl -H "Authorization: Bearer $TESLAFI_API_TOKEN" "https://www.teslafi.com/feed.php?command=sleep"
-    log "also initiated TeslaFi Sleep Mode to give the car a chance to fall asleep." 
+  # Initiate TeslaFi Sleep Mode
+  if [[ -n "${TESLAFI_API_TOKEN:+x}" ]]; then
+    curl -s -H "Authorization: Bearer $TESLAFI_API_TOKEN" "https://www.teslafi.com/feed.php?command=sleep"
+    log "Initiated TeslaFi Sleep Mode to allow the car to fall asleep."
   fi
 fi

--- a/run/awake_stop
+++ b/run/awake_stop
@@ -35,10 +35,4 @@ if [ -e /tmp/keep_awake_task_pid ]; then
   log "Stopping wake car background task."
   kill "$(cat /tmp/keep_awake_task_pid)" || true
   rm -f /tmp/keep_awake_task_pid
-
-  # Initiate TeslaFi Sleep Mode
-  if [[ -n "${TESLAFI_API_TOKEN:+x}" ]]; then
-    curl -s -H "Authorization: Bearer $TESLAFI_API_TOKEN" "https://www.teslafi.com/feed.php?command=sleep"
-    log "Initiated TeslaFi Sleep Mode to allow the car to fall asleep."
-  fi
 fi

--- a/run/cifs_archive/copy-music.sh
+++ b/run/cifs_archive/copy-music.sh
@@ -4,93 +4,63 @@ SRC="/mnt/musicarchive"
 DST="/mnt/music"
 LOG="/tmp/rsyncmusiclog.txt"
 
-# check that DST is the mounted disk image, not the mountpoint directory
-if ! findmnt --mountpoint $DST > /dev/null
-then
+# Check that DST is the mounted disk image, not the mountpoint directory
+if ! findmnt --mountpoint "$DST" > /dev/null; then
   log "$DST not mounted, skipping music sync"
   exit
 fi
 
-function connectionmonitor {
-  while true
-  do
-    for _ in {1..10}
-    do
-      if timeout 3 /root/bin/archive-is-reachable.sh "$ARCHIVE_SERVER"
-      then
-        # sleep and then continue outer loop
-        sleep 5
-        continue 2
-      fi
-      sleep 1
-    done
-    log "connection dead, killing copy-music"
-    # Give rsync a chance to clean up before killing it hard.
-    killall rsync || true
-    sleep 2
-    killall -9 rsync || true
-    kill -9 "$1" || true
-    return
-  done
-}
-
 function do_music_sync {
   log "Syncing music from archive..."
 
-  # return immediately if the archive mount can't be accessed
-  if ! timeout 5 stat "$SRC" > /dev/null
-  then
+  # Ensure SRC is accessible
+  if ! timeout 5 stat "$SRC" > /dev/null; then
     log "Error: $SRC is not accessible"
     return
   fi
 
-  # check that SRC is the mounted cifs archive and not the empty mountpoint
-  # directory, since the latter would cause all music to be deleted from DST
-  if ! findmnt --mountpoint $SRC > /dev/null
-  then
+  # Ensure SRC is mounted
+  if ! findmnt --mountpoint "$SRC" > /dev/null; then
     log "Error: $SRC not mounted"
     return
   fi
 
-  connectionmonitor $$ &
-
   if ! rsync -rum --no-human-readable --exclude=.fseventsd/*** --exclude=*.DS_Store --exclude=.metadata_never_index \
                 --exclude="System Volume Information/***" \
-                --delete --modify-window=2 --info=stats2 "$SRC/" "$DST" &> "$LOG"
-  then
+                --delete --modify-window=2 --info=stats2 "$SRC/" "$DST" &> "$LOG"; then
     log "rsync failed with error $?"
   fi
 
-  # Stop the connection monitor.
-  kill %1 || true
+  # Remove empty directories
+  find "$DST" -depth -type d -empty -delete || true
 
-  # remove empty directories
-  find $DST -depth -type d -empty -delete || true
-
-  # parse log for relevant info
+  # Parse log for relevant info
   declare -i NUM_FILES_COPIED
-  NUM_FILES_COPIED=$(($(sed -n -e 's/\(^Number of regular files transferred: \)\([[:digit:]]\+\).*/\2/p' "$LOG")))
+  NUM_FILES_COPIED=$(sed -n -e 's/\(^Number of regular files transferred: \)\([[:digit:]]\+\).*/\2/p' "$LOG")
   declare -i NUM_FILES_DELETED
-  NUM_FILES_DELETED=$(($(sed -n -e 's/\(^Number of deleted files: [[:digit:]]\+ (reg: \)\([[:digit:]]\+\)*.*/\2/p' "$LOG")))
+  NUM_FILES_DELETED=$(sed -n -e 's/\(^Number of deleted files: [[:digit:]]\+ (reg: \)\([[:digit:]]\+\)*.*/\2/p' "$LOG")
   declare -i TOTAL_FILES
   TOTAL_FILES=$(sed -n -e 's/\(^Number of files: [[:digit:]]\+ (reg: \)\([[:digit:]]\+\)*.*/\2/p' "$LOG")
   declare -i NUM_FILES_ERROR
-  NUM_FILES_ERROR=$(($(grep -c "failed to open" $LOG || true)))
+  NUM_FILES_ERROR=$(grep -c "failed to open" "$LOG" || true)
 
-  declare -i NUM_FILES_SKIPPED=$((TOTAL_FILES-NUM_FILES_COPIED))
-  NUM_FILES_COPIED=$((NUM_FILES_COPIED-NUM_FILES_ERROR))
+  declare -i NUM_FILES_SKIPPED=$((TOTAL_FILES - NUM_FILES_COPIED))
+  NUM_FILES_COPIED=$((NUM_FILES_COPIED - NUM_FILES_ERROR))
 
-  local message="Copied $NUM_FILES_COPIED music file(s), deleted $NUM_FILES_DELETED, skipped $NUM_FILES_SKIPPED previously-copied files, and encountered $NUM_FILES_ERROR errors."
-
-  if [ $NUM_FILES_COPIED -ne 0 ] || [ $NUM_FILES_DELETED -ne 0 ] || [ $NUM_FILES_ERROR -ne 0 ]
-  then
-    /root/bin/send-push-message "$NOTIFICATION_TITLE:" "$message"
+  # Generate sync summary message (Always log, even if nothing changed)
+  if [ "$NUM_FILES_COPIED" -eq 0 ] && [ "$NUM_FILES_DELETED" -eq 0 ] && [ "$NUM_FILES_ERROR" -eq 0 ]; then
+    log "Music Sync Completed: No files copied, deleted, or modified. All files are up to date."
   else
-    log "$message"
+    log "Music Sync Completed: Copied $NUM_FILES_COPIED file(s), deleted $NUM_FILES_DELETED, skipped $NUM_FILES_SKIPPED, and encountered $NUM_FILES_ERROR errors."
+  fi
+
+  # Send notification **ONLY if files were copied/deleted or errors occurred**
+  if [ "$NUM_FILES_COPIED" -ne 0 ] || [ "$NUM_FILES_DELETED" -ne 0 ] || [ "$NUM_FILES_ERROR" -ne 0 ]; then
+    /root/bin/send-push-message "$NOTIFICATION_TITLE:" "🎵 Music Sync Completed: Copied $NUM_FILES_COPIED, Deleted $NUM_FILES_DELETED, Skipped $NUM_FILES_SKIPPED, Errors $NUM_FILES_ERROR."
   fi
 }
 
-if ! do_music_sync
-then
+# Start music sync
+if ! do_music_sync; then
   log "Error while syncing music"
 fi


### PR DESCRIPTION
This update fixes the awake_start and awake_stop scripts. It checks sentry state from TeslaFi directly. If sentry mode is already on then it leaves it on after the archive process. If it was not on, it will turn off. This ensures that user's who want sentry mode on in the first place will be left with it on. Otherwise sentry mode gets turned back off after the archive process. 