### PR TITLE
Monitor wifi connectivity

### DIFF
--- a/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
+++ b/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
@@ -16,6 +16,13 @@
 export SSID='your_ssid'
 export WIFIPASS='your_pass'
 
+# Wi-Fi connectivity check settings (optional)
+# pi will check wifi connectivity on a 60-seconds internal.
+# pi will reboot if SSID is in range, but not connected after WIFI_MAX_FAILS
+# If SSID and WIFI_MAX_FAILS are defined, Wi-Fi monitoring is enabled
+# If any one SSID or WIFI_MAX_FAILS is undefined or commented out, Wi-Fi monitoring is skipped
+#export WIFI_MAX_FAILS = 3 
+
 # Variables for CIFS (Windows/Mac file sharing) archiving.
 # If you want to use rsync or rclone, delete or comment out this section
 # and uncomment the rsync or rclone section below.

--- a/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
+++ b/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
@@ -17,10 +17,10 @@ export SSID='your_ssid'
 export WIFIPASS='your_pass'
 
 # Wifi connectivity check settings (optional)
-# If SSID, WIFI_MAX_FAILS, PING_HOST are defined, Wi-Fi monitoring is enabled.
-# If any out of the 3 are not defined or commented out, Wi-Fi monitoring is disabled.
-# PING_HOST ideally should be your router/gateway's ip, or an device in the local network.
-# Ensure PING_HOST responses to ping request.
+# If SSID, WIFI_MAX_FAILS are defined, Wi-Fi monitoring is enabled.
+# If any out of the 2 are not defined or commented out, Wi-Fi monitoring is disabled.
+# PING_HOST is optional. If not specified, default gateway will be used.
+# Ensure default gateway (or PING_HOST) responses to ping request.
 # Wifi connectivity will performed check every 60 seconds.
 # TeslaUSB will reboot if it detects SSID in range, but PING_HOST is unreachable after WIFI_MAX_FAILS
 #export WIFI_MAX_FAILS=3

--- a/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
+++ b/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
@@ -20,7 +20,7 @@ export WIFIPASS='your_pass'
 # Wi-Fi monitoring requires SSID and MAX_FAILS; PING_HOST is optional
 # TeslaUSB will check wifi connectivity on a 60-seconds internal.
 # TeslaUSB will reboot if SSID is in range, but ping failed after WIFI_MAX_FAILS
-#export WIFI_MAX_FAILS = 3
+#export MAX_FAILS  = 3
 #export PING_HOST="192.168.1.1"    # Host to ping for connectivity; defaults to 8.8.8.8 if unset
 
 # Variables for CIFS (Windows/Mac file sharing) archiving.

--- a/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
+++ b/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
@@ -17,14 +17,12 @@ export SSID='your_ssid'
 export WIFIPASS='your_pass'
 
 # Wifi connectivity check settings (optional)
-# If SSID, WIFI_MAX_FAILS are defined, Wi-Fi monitoring is enabled.
-# If any out of the 2 are not defined or commented out, Wi-Fi monitoring is disabled.
-# PING_HOST is optional. If not specified, default gateway will be used.
-# Ensure default gateway (or PING_HOST) responses to ping request.
-# Wifi connectivity will performed check every 60 seconds.
-# TeslaUSB will reboot if it detects SSID in range, but PING_HOST is unreachable after WIFI_MAX_FAILS
-#export WIFI_MAX_FAILS=3
-#export PING_HOST='192.168.1.1'
+# If SSID, WIFI_MAX_FAILS are defined, Wi-Fi monitoring is enabled
+# If any out of the 2 are not defined or commented out, Wifi monitoring is disabled
+# Wifi monitoring will check connectivity every 60 secs. It will reboot teslausb when
+# SSID is in range but not connected after WIFI_MAX_FAILS
+# SSID was connected but disconnected for WIFI_MAX_FAILS
+export WIFI_MAX_FAILS=3
 
 # Variables for CIFS (Windows/Mac file sharing) archiving.
 # If you want to use rsync or rclone, delete or comment out this section

--- a/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
+++ b/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
@@ -17,11 +17,11 @@ export SSID='your_ssid'
 export WIFIPASS='your_pass'
 
 # Wi-Fi connectivity check settings (optional)
-# pi will check wifi connectivity on a 60-seconds internal.
-# pi will reboot if SSID is in range, but not connected after WIFI_MAX_FAILS
-# If SSID and WIFI_MAX_FAILS are defined, Wi-Fi monitoring is enabled
-# If any one SSID or WIFI_MAX_FAILS is undefined or commented out, Wi-Fi monitoring is skipped
-#export WIFI_MAX_FAILS = 3 
+# Wi-Fi monitoring requires SSID and MAX_FAILS; PING_HOST is optional
+# TeslaUSB will check wifi connectivity on a 60-seconds internal.
+# TeslaUSB will reboot if SSID is in range, but ping failed after WIFI_MAX_FAILS
+#export WIFI_MAX_FAILS = 3
+#export PING_HOST="192.168.1.1"    # Host to ping for connectivity; defaults to 8.8.8.8 if unset
 
 # Variables for CIFS (Windows/Mac file sharing) archiving.
 # If you want to use rsync or rclone, delete or comment out this section

--- a/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
+++ b/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
@@ -16,12 +16,15 @@
 export SSID='your_ssid'
 export WIFIPASS='your_pass'
 
-# Wi-Fi connectivity check settings (optional)
-# Wi-Fi monitoring requires SSID and MAX_FAILS; PING_HOST is optional
-# TeslaUSB will check wifi connectivity on a 60-seconds internal.
-# TeslaUSB will reboot if SSID is in range, but ping failed after WIFI_MAX_FAILS
-#export MAX_FAILS  = 3
-#export PING_HOST="192.168.1.1"    # Host to ping for connectivity; defaults to 8.8.8.8 if unset
+# Wifi connectivity check settings (optional)
+# If SSID, WIFI_MAX_FAILS, PING_HOST are defined, Wi-Fi monitoring is enabled.
+# If any out of the 3 are not defined or commented out, Wi-Fi monitoring is disabled.
+# PING_HOST ideally should be your router/gateway's ip, or an device in the local network.
+# Ensure PING_HOST responses to ping request.
+# Wifi connectivity will performed check every 60 seconds.
+# TeslaUSB will reboot if it detects SSID in range, but PING_HOST is unreachable after WIFI_MAX_FAILS
+#export WIFI_MAX_FAILS=3
+#export PING_HOST='192.168.1.1'
 
 # Variables for CIFS (Windows/Mac file sharing) archiving.
 # If you want to use rsync or rclone, delete or comment out this section

--- a/run/archiveloop
+++ b/run/archiveloop
@@ -856,6 +856,8 @@ function monitor_wifi_connectivity {
     WIFI_TOOL="wpa_cli"  # Use wpa_cli if nmcli isn’t available
   fi
 
+  log "Wifi monitoring enabled: SSID=$SSID, WIFI_MAX_FAILS=$WIFI_MAX_FAILS, PING_HOST=${PING_HOST:-default gateway} using $WIFI_TOOL"
+
   while true
   do
     # Perform wifi scan based on current tool

--- a/run/archiveloop
+++ b/run/archiveloop
@@ -827,37 +827,66 @@ function wifichecker {
 function monitor_wifi_connectivity {
   echo -n wificonnmonitor > /proc/self/comm
   local FAIL_COUNT=0  # In-memory counter
+
+  # Check if SSID, WIFI_MAX_FAILS, and PING_HOST are defined and non-empty
+  if [ -z "$SSID" ] || [ -z "$WIFI_MAX_FAILS" ] || [ -z "$PING_HOST" ]
+  then
+    log "Wifi monitoring disabled: SSID, WIFI_MAX_FAILS, and PING_HOST must all be defined (SSID=$SSID, WIFI_MAX_FAILS=$WIFI_MAX_FAILS, PING_HOST=$PING_HOST)"
+    return
+  fi
+
+  # Determine wifi management tool
+  local WIFI_TOOL=""
+  if command -v nmcli >/dev/null 2>&1
+  then
+    WIFI_TOOL="nmcli"
+  elif command -v wpa_cli >/dev/null 2>&1
+  then
+    WIFI_TOOL="wpa_cli"
+  else
+    log "Wifi management tool not found (nmcli or wpa_cli required)"
+    return
+  fi
+
+  log "Wifi monitoring enabled: SSID=$SSID, WIFI_MAX_FAILS=$WIFI_MAX_FAILS, PING_HOST=$PING_HOST using $WIFI_TOOL"
+
   while true
   do
-    # Check only if both SSID and MAX_FAILS are defined and non-empty
-    if [ -n "$SSID" ] && [ -n "$MAX_FAILS" ]; then
-      # Force a fresh Wi-Fi scan
-      nmcli dev wifi rescan >/dev/null 2>&1 || log "Wi-Fi rescan failed"
-      sleep 2  # Give scan time to complete
+    # Perform wifi scan based on tool
+    if [ "$WIFI_TOOL" = "nmcli" ]
+    then
+      nmcli dev wifi rescan >/dev/null 2>&1 || log "Wifi rescan failed with NetworkManager"
+      sleep 2
+      IN_RANGE=$(nmcli -t -f SSID dev wifi list | grep -q "^$SSID$" && echo "yes" || echo "no")
+      VISIBLE_SSIDS=$(nmcli -t -f SSID dev wifi | grep -v '^$' | tr '\n' ',' | sed 's/,/, /g; s/, $//')
+    elif [ "$WIFI_TOOL" = "wpa_cli" ]
+    then
+      wpa_cli scan >/dev/null 2>&1 || log "Wifi rescan failed with wpa_supplicant"
+      sleep 2
+      IN_RANGE=$(wpa_cli scan_results | tail -n +3 | grep -q "$SSID" && echo "yes" || echo "no")
+      VISIBLE_SSIDS=$(wpa_cli scan_results | tail -n +3 | awk '{print $5}' | grep -v '^$' | tr '\n' ',' | sed 's/,/, /g; s/, $//')
+    fi
 
-      # Set the host to ping (default to 8.8.8.8 if not defined)
-      : "${PING_HOST:=8.8.8.8}"
-
-      # Check if $SSID is in range using terse output
-      if nmcli -t -f SSID dev wifi list | grep -q "^$SSID$"; then
-        # Log visible SSIDs as comma-space-separated list
-        VISIBLE_SSIDS=$(nmcli -t -f SSID dev wifi | grep -v '^$' | tr '\n' ',' | sed 's/,/, /g; s/, $//')
-        # Ping the host to test connectivity (1 packet, 2-second timeout)
-        if ping -c 1 -W 2 "$PING_HOST" >/dev/null 2>&1; then
-          FAIL_COUNT=0
-          log "$SSID in range and connected (ping to $PING_HOST succeeded). Counter reset."
-        else
-          FAIL_COUNT=$((FAIL_COUNT + 1))
-          log "$SSID in range but not connected (ping to $PING_HOST failed, visible SSIDs: ${VISIBLE_SSIDS:-none}). Fail count: $FAIL_COUNT"
-          if [ "$FAIL_COUNT" -ge "$MAX_FAILS" ]; then
-            log "$MAX_FAILS consecutive failures. Rebooting..."
-            reboot
-          fi
-        fi
-      else
+    # Check if SSID is in range
+    if [ "$IN_RANGE" = "yes" ]
+    then
+      # Test connectivity with ping
+      if ping -c 1 -W 2 "$PING_HOST" >/dev/null 2>&1
+      then
         FAIL_COUNT=0
-        log "$SSID not in range. Counter reset."
+        log "$SSID in range and connected (ping to $PING_HOST succeeded). Counter reset."
+      else
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+        log "$SSID in range but not connected (ping to $PING_HOST failed, visible SSIDs: ${VISIBLE_SSIDS:-none}). Fail count: $FAIL_COUNT"
+        if [ "$FAIL_COUNT" -ge "$WIFI_MAX_FAILS" ]
+        then
+          log "$WIFI_MAX_FAILS consecutive failures. Rebooting..."
+          reboot
+        fi
       fi
+    else
+      FAIL_COUNT=0
+      log "$SSID not in range. Counter reset."
     fi
     sleep 60
   done

--- a/run/archiveloop
+++ b/run/archiveloop
@@ -829,28 +829,28 @@ function monitor_wifi_connectivity {
   local FAIL_COUNT=0  # In-memory counter
   while true
   do
-    # Check only if both SSID and WIFI_MAX_FAILS are defined and non-empty
-    if [ -n "$SSID" ] && [ -n "$WIFI_MAX_FAILS" ]; then
+    # Check only if both SSID and MAX_FAILS are defined and non-empty
+    if [ -n "$SSID" ] && [ -n "$MAX_FAILS" ]; then
       # Force a fresh Wi-Fi scan
       nmcli dev wifi rescan >/dev/null 2>&1 || log "Wi-Fi rescan failed"
       sleep 2  # Give scan time to complete
 
-      # Get all active SSIDs (could be multiple)
-      ACTIVE_SSIDS=$(nmcli -t -f ACTIVE,SSID dev wifi | grep '^yes' | cut -d':' -f2)
+      # Set the host to ping (default to 8.8.8.8 if not defined)
+      : "${PING_HOST:=8.8.8.8}"
 
       # Check if $SSID is in range using terse output
       if nmcli -t -f SSID dev wifi list | grep -q "^$SSID$"; then
         # Log visible SSIDs as comma-space-separated list
         VISIBLE_SSIDS=$(nmcli -t -f SSID dev wifi | grep -v '^$' | tr '\n' ',' | sed 's/,/, /g; s/, $//')
-        # Check if $SSID is among the active SSIDs
-        if echo "$ACTIVE_SSIDS" | grep -q "^$SSID$"; then
+        # Ping the host to test connectivity (1 packet, 2-second timeout)
+        if ping -c 1 -W 2 "$PING_HOST" >/dev/null 2>&1; then
           FAIL_COUNT=0
-          log "$SSID in range and connected. Counter reset."
+          log "$SSID in range and connected (ping to $PING_HOST succeeded). Counter reset."
         else
           FAIL_COUNT=$((FAIL_COUNT + 1))
-          log "$SSID in range but not connected (active SSIDs: ${ACTIVE_SSIDS:-none}, visible SSIDs: ${VISIBLE_SSIDS:-none}). Fail count: $FAIL_COUNT"
-          if [ "$FAIL_COUNT" -ge "$WIFI_MAX_FAILS" ]; then
-            log "$WIFI_MAX_FAILS consecutive failures. Rebooting..."
+          log "$SSID in range but not connected (ping to $PING_HOST failed, visible SSIDs: ${VISIBLE_SSIDS:-none}). Fail count: $FAIL_COUNT"
+          if [ "$FAIL_COUNT" -ge "$MAX_FAILS" ]; then
+            log "$MAX_FAILS consecutive failures. Rebooting..."
             reboot
           fi
         fi

--- a/run/archiveloop
+++ b/run/archiveloop
@@ -824,148 +824,81 @@ function wifichecker {
   }
 }
 
-function monitor_wifi_connectivity {
+function monitor_wifi_connectivity() {
   echo -n wificonnmonitor > /proc/self/comm
-  local FAIL_COUNT=0  # In-memory counter
+  set +e  # Don't die on non-zero exit codes unless explicitly handled
+  local fail_count=0
+  local wifi_disconnect_monitor=0
 
-  # Check if SSID and WIFI_MAX_FAILS are defined and non-empty
+  trap 'ec=$?; if [ $ec -ne 0 ]; then log "Wifi Monitoring: Script terminated unexpectedly with exit code $ec."; else log "Wifi Monitoring: Script exiting cleanly."; fi' EXIT
+  trap 'log "Wifi Monitoring: Received SIGTERM. Exiting."; exit 1' SIGTERM
+  trap 'log "Wifi Monitoring: Received SIGINT. Exiting."; exit 1' SIGINT
+
+  # Check if required variables are set
   if [ -z "$SSID" ] || [ -z "$WIFI_MAX_FAILS" ]
   then
-    log "Wifi monitoring disabled: SSID and WIFI_MAX_FAILS must be defined (SSID=$SSID, WIFI_MAX_FAILS=$WIFI_MAX_FAILS)"
-    return
+    log "Wifi Monitoring: SSID or WIFI_MAX_FAILS not set. Wifi monitoring disabled."
+    return 0
   fi
 
-  # Determine available wifi management tools and set initial tool
-  local NMCLI_AVAILABLE=""
-  local WPA_CLI_AVAILABLE=""
-  local WIFI_TOOL="nmcli"  # Default to nmcli
-  if command -v nmcli >/dev/null 2>&1
+  # Ensure 'iw' is available
+  if ! command -v iw >/dev/null 2>&1
   then
-    NMCLI_AVAILABLE="yes"
-  fi
-  if command -v wpa_cli >/dev/null 2>&1
-  then
-    WPA_CLI_AVAILABLE="yes"
-  fi
-  if [ -z "$NMCLI_AVAILABLE" ] && [ -z "$WPA_CLI_AVAILABLE" ]
-  then
-    log "Wifi management tool not found (nmcli or wpa_cli required)"
-    return
-  elif [ -z "$NMCLI_AVAILABLE" ]
-  then
-    WIFI_TOOL="wpa_cli"  # Use wpa_cli if nmcli isn’t available
+    log "ERROR: 'iw' command not found. Exiting."
+    return 1
   fi
 
-  log "Wifi monitoring enabled: SSID=$SSID, WIFI_MAX_FAILS=$WIFI_MAX_FAILS, PING_HOST=${PING_HOST:=default} using $WIFI_TOOL"
-
-  #Start of monitoring
   while true
   do
-    # Perform wifi scan based on current tool
-    if [ "$WIFI_TOOL" = "nmcli" ]
-    then
-      if nmcli dev wifi rescan >/dev/null 2>&1
-      then
-        sleep 2
-        IN_RANGE=$(nmcli -t -f SSID dev wifi list | grep -q "^$SSID$" && echo "yes" || echo "no")
-        VISIBLE_SSIDS=$(nmcli -t -f SSID dev wifi | grep -v '^$' | tr '\n' ',' | sed 's/,/, /g; s/, $//')
-      else
-        log "Wifi rescan failed with NetworkManager, switching to wpa_supplicant"
-        if [ -n "$WPA_CLI_AVAILABLE" ]
-        then
-          WIFI_TOOL="wpa_cli"
-        fi
-        IN_RANGE="no"  # Assume not in range on scan failure
-        VISIBLE_SSIDS=""
-      fi
-    elif [ "$WIFI_TOOL" = "wpa_cli" ]
-    then
-      if wpa_cli scan >/dev/null 2>&1
-      then
-        sleep 2
-        IN_RANGE=$(wpa_cli scan_results | tail -n +3 | grep -q "$SSID" && echo "yes" || echo "no")
-        VISIBLE_SSIDS=$(wpa_cli scan_results | tail -n +3 | awk '{print $5}' | grep -v '^$' | tr '\n' ',' | sed 's/,/, /g; s/, $//')
-      else
-        log "Wifi rescan failed with wpa_supplicant, switching to NetworkManager"
-        if [ -n "$NMCLI_AVAILABLE" ]
-        then
-          WIFI_TOOL="nmcli"
-        fi
-        IN_RANGE="no"  # Assume not in range on scan failure
-        VISIBLE_SSIDS=""
-      fi
-    fi
-
-log "In LOOP: Wifi monitoring enabled: SSID=$SSID, WIFI_MAX_FAILS=$WIFI_MAX_FAILS, PING_HOST=${PING_HOST:-default} using $WIFI_TOOL inrange $IN_RANGE"
-    # Check if SSID is in range
-    if [ "$IN_RANGE" = "yes" ]
-    then
-      # Determine ping target (PING_HOST or default gateway)
-      #local PING_TARGET="$PING_HOST"
-      local PING_TARGET=""
-log "IN RANGE IF"
-      if [ "${PING_HOST:-default}" = "default" ]
-#      if [ -z "$PING_HOST" ]
-      then
-log "Ping Target before ip route: $PING_TARGET"
-        PING_TARGET=$(ip route | grep default | awk '{print $3}' | head -n 1)
-log "Ping Target after ip route: $PING_TARGET"
-        if [ "$PING_TARGET" = "" ]
-        then
-          PING_TARGET="unreachable"
-          FAIL_COUNT=$((FAIL_COUNT + 1))
-          log "$SSID in range but unable to resolve default gateway, visible SSIDs: ${VISIBLE_SSIDS:-none}). Fail count: $FAIL_COUNT"
-          if [ "$FAIL_COUNT" -ge "$WIFI_MAX_FAILS" ]
-          then
-            log "$WIFI_MAX_FAILS consecutive failures. Rebooting..."
-            reboot
-          fi
-        else
-          log "SSID in range. ping target $PING_TARGET"
-        fi
-      fi
-
-      # Test connectivity with ping (skip if PING_TARGET is unreachable)
-      if [ "$PING_TARGET" != "unreachable" ]
-      then
-        # Test connectivity with ping
-        if ping -c 1 -W 2 "$PING_TARGET" >/dev/null 2>&1
-        then
-          FAIL_COUNT=0
-          log "$SSID in range and connected (ping to $PING_TARGET succeeded). Counter reset."
-        else
-          # Attempt to connect to the SSID
-          if [ "$WIFI_TOOL" = "nmcli" ]
-          then
-            nmcli dev wifi connect "$SSID" >/dev/null 2>&1 && log "Attempted to connect to $SSID with NetworkManager" || log "Failed to connect to $SSID with NetworkManager"
-            WIFI_TOOL="wpa_cli" # Attempt to use the other WIFI_TOOL next time if not connected
-          elif [ "$WIFI_TOOL" = "wpa_cli" ]
-          then
-            NETWORK_ID=$(wpa_cli list_networks | awk -v ssid="^$SSID$" '$2 ~ ssid {print $1}')
-            if [ -n "$NETWORK_ID" ]
-            then
-              wpa_cli select_network "$NETWORK_ID" >/dev/null 2>&1 && log "Attempted to connect to $SSID (network ID $NETWORK_ID) with wpa_supplicant" || log "Failed to connect to $SSID (network ID $NETWORK_ID) with wpa_supplicant"
-              WIFI_TOOL="nmcli" # Attempt to use the other WIFI_TOOL next time if not connected
-            else
-              log "No network ID found for $SSID in wpa_supplicant configuration"
-            fi
-          fi
-
-          FAIL_COUNT=$((FAIL_COUNT + 1))
-          log "$SSID in range but not connected (ping to $PING_TARGET failed, visible SSIDs: ${VISIBLE_SSIDS:-none}). Fail count: $FAIL_COUNT"
-          if [ "$FAIL_COUNT" -ge "$WIFI_MAX_FAILS" ]
-          then
-            log "$WIFI_MAX_FAILS consecutive failures. Rebooting..."
-            reboot
-          fi
-        fi
-      fi
-    else
-      FAIL_COUNT=0
-      log "$SSID not in range. Counter reset."
-    fi
- #   log "sleep"
     sleep 60
+
+    # Perform the scan once and store results in a variable
+    local scan_output
+    scan_output=$(timeout 10s iw dev wlan0 scan 2>/dev/null | awk -F'SSID: ' '/SSID:/ {print $2}')
+
+    # Check if SSID is in range
+    local ssid_in_range=0
+    if echo "$scan_output" | grep -Fxq "$SSID"
+    then
+      ssid_in_range=1
+    fi
+
+    # Find default gateway
+    local gateway=""
+    gateway=$(timeout 5s ip route | awk '/default/ {print $3}' | head -n1)
+
+    # Check connectivity
+    local connected=0
+    if [ -n "$gateway" ]
+    then
+      if timeout 5s ping -c 1 -W 5 "$gateway" >/dev/null 2>&1
+      then
+        connected=1
+      fi
+    fi
+
+    # Handle wifi conditions
+    if [ "$connected" -eq 1 ]
+    then
+      wifi_disconnect_monitor=1
+      fail_count=0
+      log "Wifi Monitoring: SSID '$SSID' connected."
+    elif [ "$connected" -eq 0 ] && [ "$ssid_in_range" -eq 1 ]
+    then
+      ((fail_count++))
+      log "Wifi Monitoring: Fail $fail_count of $WIFI_MAX_FAILS. SSID '$SSID' in range but not connected."
+    elif [ "$connected" -eq 0 ] && [ "$wifi_disconnect_monitor" -eq 1 ]
+  	then
+      ((fail_count++))
+      log "Wifi Monitoring: Fail $fail_count of $WIFI_MAX_FAILS. SSID '$SSID' disconnected."
+    fi
+
+    if [ "$fail_count" -ge "$WIFI_MAX_FAILS" ]
+	  then
+      log "Wifi Monitoring: Persistent wifi failure detected. Wait for idle and reboot."
+      /root/bin/waitforidle || true
+      reboot
+    fi
   done
 }
 

--- a/run/archiveloop
+++ b/run/archiveloop
@@ -824,6 +824,45 @@ function wifichecker {
   }
 }
 
+function monitor_wifi_connectivity {
+  echo -n wificonnmonitor > /proc/self/comm
+  local FAIL_COUNT=0  # In-memory counter
+  while true
+  do
+    # Check only if both SSID and WIFI_MAX_FAILS are defined and non-empty
+    if [ -n "$SSID" ] && [ -n "$WIFI_MAX_FAILS" ]; then
+      # Force a fresh Wi-Fi scan
+      nmcli dev wifi rescan >/dev/null 2>&1 || log "Wi-Fi rescan failed"
+      sleep 2  # Give scan time to complete
+
+      # Get all active SSIDs (could be multiple)
+      ACTIVE_SSIDS=$(nmcli -t -f ACTIVE,SSID dev wifi | grep '^yes' | cut -d':' -f2)
+
+      # Check if $SSID is in range using terse output
+      if nmcli -t -f SSID dev wifi list | grep -q "^$SSID$"; then
+        # Log visible SSIDs as comma-space-separated list
+        VISIBLE_SSIDS=$(nmcli -t -f SSID dev wifi | grep -v '^$' | tr '\n' ',' | sed 's/,/, /g; s/, $//')
+        # Check if $SSID is among the active SSIDs
+        if echo "$ACTIVE_SSIDS" | grep -q "^$SSID$"; then
+          FAIL_COUNT=0
+          log "$SSID in range and connected. Counter reset."
+        else
+          FAIL_COUNT=$((FAIL_COUNT + 1))
+          log "$SSID in range but not connected (active SSIDs: ${ACTIVE_SSIDS:-none}, visible SSIDs: ${VISIBLE_SSIDS:-none}). Fail count: $FAIL_COUNT"
+          if [ "$FAIL_COUNT" -ge "$WIFI_MAX_FAILS" ]; then
+            log "$WIFI_MAX_FAILS consecutive failures. Rebooting..."
+            reboot
+          fi
+        fi
+      else
+        FAIL_COUNT=0
+        log "$SSID not in range. Counter reset."
+      fi
+    fi
+    sleep 60
+  done
+}
+
 function set_sys_param() {
   local -r parampath="$1"
   local -r var="$2"
@@ -858,6 +897,7 @@ then
 fi
 logrotator &
 wifichecker &
+monitor_wifi_connectivity &
 
 fix_errors_in_images
 # always remove files that fsck recoverd

--- a/run/archiveloop
+++ b/run/archiveloop
@@ -856,8 +856,9 @@ function monitor_wifi_connectivity {
     WIFI_TOOL="wpa_cli"  # Use wpa_cli if nmcli isn’t available
   fi
 
-  log "Wifi monitoring enabled: SSID=$SSID, WIFI_MAX_FAILS=$WIFI_MAX_FAILS, PING_HOST=${PING_HOST:-default gateway} using $WIFI_TOOL"
+  log "Wifi monitoring enabled: SSID=$SSID, WIFI_MAX_FAILS=$WIFI_MAX_FAILS, PING_HOST=${PING_HOST:=default} using $WIFI_TOOL"
 
+  #Start of monitoring
   while true
   do
     # Perform wifi scan based on current tool
@@ -895,55 +896,75 @@ function monitor_wifi_connectivity {
       fi
     fi
 
+log "In LOOP: Wifi monitoring enabled: SSID=$SSID, WIFI_MAX_FAILS=$WIFI_MAX_FAILS, PING_HOST=${PING_HOST:-default} using $WIFI_TOOL inrange $IN_RANGE"
     # Check if SSID is in range
     if [ "$IN_RANGE" = "yes" ]
     then
       # Determine ping target (PING_HOST or default gateway)
-      local PING_TARGET="$PING_HOST"
-      if [ -z "$PING_TARGET" ]
+      #local PING_TARGET="$PING_HOST"
+      local PING_TARGET=""
+log "IN RANGE IF"
+      if [ "${PING_HOST:-default}" = "default" ]
+#      if [ -z "$PING_HOST" ]
       then
+log "Ping Target before ip route: $PING_TARGET"
         PING_TARGET=$(ip route | grep default | awk '{print $3}' | head -n 1)
-        if [ -z "$PING_TARGET" ]
+log "Ping Target after ip route: $PING_TARGET"
+        if [ "$PING_TARGET" = "" ]
         then
-          PING_TARGET="unknown (no default gateway)"
+          PING_TARGET="unreachable"
+          FAIL_COUNT=$((FAIL_COUNT + 1))
+          log "$SSID in range but unable to resolve default gateway, visible SSIDs: ${VISIBLE_SSIDS:-none}). Fail count: $FAIL_COUNT"
+          if [ "$FAIL_COUNT" -ge "$WIFI_MAX_FAILS" ]
+          then
+            log "$WIFI_MAX_FAILS consecutive failures. Rebooting..."
+            reboot
+          fi
+        else
+          log "SSID in range. ping target $PING_TARGET"
         fi
       fi
 
-      # Test connectivity with ping
-      if ping -c 1 -W 2 "$PING_TARGET" >/dev/null 2>&1
+      # Test connectivity with ping (skip if PING_TARGET is unreachable)
+      if [ "$PING_TARGET" != "unreachable" ]
       then
-        FAIL_COUNT=0
-        log "$SSID in range and connected (ping to $PING_TARGET succeeded). Counter reset."
-      else
-        # Attempt to connect to the SSID
-        if [ "$WIFI_TOOL" = "nmcli" ]
+        # Test connectivity with ping
+        if ping -c 1 -W 2 "$PING_TARGET" >/dev/null 2>&1
         then
-          nmcli dev wifi connect "$SSID" >/dev/null 2>&1 && log "Attempted to connect to $SSID with NetworkManager" || log "Failed to connect to $SSID with NetworkManager"
-          WIFI_TOOL="wpa_cli" # Attempt to use the other WIFI_TOOL next time if not connected
-        elif [ "$WIFI_TOOL" = "wpa_cli" ]
-        then
-          NETWORK_ID=$(wpa_cli list_networks | awk -v ssid="^$SSID$" '$2 ~ ssid {print $1}')
-          if [ -n "$NETWORK_ID" ]
+          FAIL_COUNT=0
+          log "$SSID in range and connected (ping to $PING_TARGET succeeded). Counter reset."
+        else
+          # Attempt to connect to the SSID
+          if [ "$WIFI_TOOL" = "nmcli" ]
           then
-            wpa_cli select_network "$NETWORK_ID" >/dev/null 2>&1 && log "Attempted to connect to $SSID (network ID $NETWORK_ID) with wpa_supplicant" || log "Failed to connect to $SSID (network ID $NETWORK_ID) with wpa_supplicant"
-            WIFI_TOOL="nmcli" # Attempt to use the other WIFI_TOOL next time if not connected
-          else
-            log "No network ID found for $SSID in wpa_supplicant configuration"
+            nmcli dev wifi connect "$SSID" >/dev/null 2>&1 && log "Attempted to connect to $SSID with NetworkManager" || log "Failed to connect to $SSID with NetworkManager"
+            WIFI_TOOL="wpa_cli" # Attempt to use the other WIFI_TOOL next time if not connected
+          elif [ "$WIFI_TOOL" = "wpa_cli" ]
+          then
+            NETWORK_ID=$(wpa_cli list_networks | awk -v ssid="^$SSID$" '$2 ~ ssid {print $1}')
+            if [ -n "$NETWORK_ID" ]
+            then
+              wpa_cli select_network "$NETWORK_ID" >/dev/null 2>&1 && log "Attempted to connect to $SSID (network ID $NETWORK_ID) with wpa_supplicant" || log "Failed to connect to $SSID (network ID $NETWORK_ID) with wpa_supplicant"
+              WIFI_TOOL="nmcli" # Attempt to use the other WIFI_TOOL next time if not connected
+            else
+              log "No network ID found for $SSID in wpa_supplicant configuration"
+            fi
           fi
-        fi
 
-        FAIL_COUNT=$((FAIL_COUNT + 1))
-        log "$SSID in range but not connected (ping to $PING_TARGET failed, visible SSIDs: ${VISIBLE_SSIDS:-none}). Fail count: $FAIL_COUNT"
-        if [ "$FAIL_COUNT" -ge "$WIFI_MAX_FAILS" ]
-        then
-          log "$WIFI_MAX_FAILS consecutive failures. Rebooting..."
-          reboot
+          FAIL_COUNT=$((FAIL_COUNT + 1))
+          log "$SSID in range but not connected (ping to $PING_TARGET failed, visible SSIDs: ${VISIBLE_SSIDS:-none}). Fail count: $FAIL_COUNT"
+          if [ "$FAIL_COUNT" -ge "$WIFI_MAX_FAILS" ]
+          then
+            log "$WIFI_MAX_FAILS consecutive failures. Rebooting..."
+            reboot
+          fi
         fi
       fi
     else
       FAIL_COUNT=0
       log "$SSID not in range. Counter reset."
     fi
+ #   log "sleep"
     sleep 60
   done
 }

--- a/run/archiveloop
+++ b/run/archiveloop
@@ -828,56 +828,110 @@ function monitor_wifi_connectivity {
   echo -n wificonnmonitor > /proc/self/comm
   local FAIL_COUNT=0  # In-memory counter
 
-  # Check if SSID, WIFI_MAX_FAILS, and PING_HOST are defined and non-empty
-  if [ -z "$SSID" ] || [ -z "$WIFI_MAX_FAILS" ] || [ -z "$PING_HOST" ]
+  # Check if SSID and WIFI_MAX_FAILS are defined and non-empty
+  if [ -z "$SSID" ] || [ -z "$WIFI_MAX_FAILS" ]
   then
-    log "Wifi monitoring disabled: SSID, WIFI_MAX_FAILS, and PING_HOST must all be defined (SSID=$SSID, WIFI_MAX_FAILS=$WIFI_MAX_FAILS, PING_HOST=$PING_HOST)"
+    log "Wifi monitoring disabled: SSID and WIFI_MAX_FAILS must be defined (SSID=$SSID, WIFI_MAX_FAILS=$WIFI_MAX_FAILS)"
     return
   fi
 
-  # Determine wifi management tool
-  local WIFI_TOOL=""
+  # Determine available wifi management tools and set initial tool
+  local NMCLI_AVAILABLE=""
+  local WPA_CLI_AVAILABLE=""
+  local WIFI_TOOL="nmcli"  # Default to nmcli
   if command -v nmcli >/dev/null 2>&1
   then
-    WIFI_TOOL="nmcli"
-  elif command -v wpa_cli >/dev/null 2>&1
+    NMCLI_AVAILABLE="yes"
+  fi
+  if command -v wpa_cli >/dev/null 2>&1
   then
-    WIFI_TOOL="wpa_cli"
-  else
+    WPA_CLI_AVAILABLE="yes"
+  fi
+  if [ -z "$NMCLI_AVAILABLE" ] && [ -z "$WPA_CLI_AVAILABLE" ]
+  then
     log "Wifi management tool not found (nmcli or wpa_cli required)"
     return
+  elif [ -z "$NMCLI_AVAILABLE" ]
+  then
+    WIFI_TOOL="wpa_cli"  # Use wpa_cli if nmcli isn’t available
   fi
-
-  log "Wifi monitoring enabled: SSID=$SSID, WIFI_MAX_FAILS=$WIFI_MAX_FAILS, PING_HOST=$PING_HOST using $WIFI_TOOL"
 
   while true
   do
-    # Perform wifi scan based on tool
+    # Perform wifi scan based on current tool
     if [ "$WIFI_TOOL" = "nmcli" ]
     then
-      nmcli dev wifi rescan >/dev/null 2>&1 || log "Wifi rescan failed with NetworkManager"
-      sleep 2
-      IN_RANGE=$(nmcli -t -f SSID dev wifi list | grep -q "^$SSID$" && echo "yes" || echo "no")
-      VISIBLE_SSIDS=$(nmcli -t -f SSID dev wifi | grep -v '^$' | tr '\n' ',' | sed 's/,/, /g; s/, $//')
+      if nmcli dev wifi rescan >/dev/null 2>&1
+      then
+        sleep 2
+        IN_RANGE=$(nmcli -t -f SSID dev wifi list | grep -q "^$SSID$" && echo "yes" || echo "no")
+        VISIBLE_SSIDS=$(nmcli -t -f SSID dev wifi | grep -v '^$' | tr '\n' ',' | sed 's/,/, /g; s/, $//')
+      else
+        log "Wifi rescan failed with NetworkManager, switching to wpa_supplicant"
+        if [ -n "$WPA_CLI_AVAILABLE" ]
+        then
+          WIFI_TOOL="wpa_cli"
+        fi
+        IN_RANGE="no"  # Assume not in range on scan failure
+        VISIBLE_SSIDS=""
+      fi
     elif [ "$WIFI_TOOL" = "wpa_cli" ]
     then
-      wpa_cli scan >/dev/null 2>&1 || log "Wifi rescan failed with wpa_supplicant"
-      sleep 2
-      IN_RANGE=$(wpa_cli scan_results | tail -n +3 | grep -q "$SSID" && echo "yes" || echo "no")
-      VISIBLE_SSIDS=$(wpa_cli scan_results | tail -n +3 | awk '{print $5}' | grep -v '^$' | tr '\n' ',' | sed 's/,/, /g; s/, $//')
+      if wpa_cli scan >/dev/null 2>&1
+      then
+        sleep 2
+        IN_RANGE=$(wpa_cli scan_results | tail -n +3 | grep -q "$SSID" && echo "yes" || echo "no")
+        VISIBLE_SSIDS=$(wpa_cli scan_results | tail -n +3 | awk '{print $5}' | grep -v '^$' | tr '\n' ',' | sed 's/,/, /g; s/, $//')
+      else
+        log "Wifi rescan failed with wpa_supplicant, switching to NetworkManager"
+        if [ -n "$NMCLI_AVAILABLE" ]
+        then
+          WIFI_TOOL="nmcli"
+        fi
+        IN_RANGE="no"  # Assume not in range on scan failure
+        VISIBLE_SSIDS=""
+      fi
     fi
 
     # Check if SSID is in range
     if [ "$IN_RANGE" = "yes" ]
     then
+      # Determine ping target (PING_HOST or default gateway)
+      local PING_TARGET="$PING_HOST"
+      if [ -z "$PING_TARGET" ]
+      then
+        PING_TARGET=$(ip route | grep default | awk '{print $3}' | head -n 1)
+        if [ -z "$PING_TARGET" ]
+        then
+          PING_TARGET="unknown (no default gateway)"
+        fi
+      fi
+
       # Test connectivity with ping
-      if ping -c 1 -W 2 "$PING_HOST" >/dev/null 2>&1
+      if ping -c 1 -W 2 "$PING_TARGET" >/dev/null 2>&1
       then
         FAIL_COUNT=0
-        log "$SSID in range and connected (ping to $PING_HOST succeeded). Counter reset."
+        log "$SSID in range and connected (ping to $PING_TARGET succeeded). Counter reset."
       else
+        # Attempt to connect to the SSID
+        if [ "$WIFI_TOOL" = "nmcli" ]
+        then
+          nmcli dev wifi connect "$SSID" >/dev/null 2>&1 && log "Attempted to connect to $SSID with NetworkManager" || log "Failed to connect to $SSID with NetworkManager"
+          WIFI_TOOL="wpa_cli" # Attempt to use the other WIFI_TOOL next time if not connected
+        elif [ "$WIFI_TOOL" = "wpa_cli" ]
+        then
+          NETWORK_ID=$(wpa_cli list_networks | awk -v ssid="^$SSID$" '$2 ~ ssid {print $1}')
+          if [ -n "$NETWORK_ID" ]
+          then
+            wpa_cli select_network "$NETWORK_ID" >/dev/null 2>&1 && log "Attempted to connect to $SSID (network ID $NETWORK_ID) with wpa_supplicant" || log "Failed to connect to $SSID (network ID $NETWORK_ID) with wpa_supplicant"
+            WIFI_TOOL="nmcli" # Attempt to use the other WIFI_TOOL next time if not connected
+          else
+            log "No network ID found for $SSID in wpa_supplicant configuration"
+          fi
+        fi
+
         FAIL_COUNT=$((FAIL_COUNT + 1))
-        log "$SSID in range but not connected (ping to $PING_HOST failed, visible SSIDs: ${VISIBLE_SSIDS:-none}). Fail count: $FAIL_COUNT"
+        log "$SSID in range but not connected (ping to $PING_TARGET failed, visible SSIDs: ${VISIBLE_SSIDS:-none}). Fail count: $FAIL_COUNT"
         if [ "$FAIL_COUNT" -ge "$WIFI_MAX_FAILS" ]
         then
           log "$WIFI_MAX_FAILS consecutive failures. Rebooting..."


### PR DESCRIPTION
Add a new process for Wifi connectivity check.

If SSID and WIFI_MAX_FAILS are defined, Wi-Fi monitoring is enabled.

Teslausb will check wifi connectivity on a 60-seconds internal.
Teslausb will reboot if SSID is in range, but not connected after WIFI_MAX_FAILS