### PR TITLE
Update keep car awake using Sentry Mode via TeslaFi & Tessie API. Deprecate obsolete Tesla API codes.

### DIFF
--- a/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
+++ b/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
@@ -240,52 +240,80 @@ export CAM_SIZE=40G
 # export TRIGGER_FILE_RECENT=ARCHIVE_UPLOADED
 # export TRIGGER_FILE_ANY=ARCHIVE_UPLOADED
 
-############################################################################
-# KEEPING THE CAR AWAKE DURING ARCHIVING USING THE TESLA API NO LONGER WORKS
+################################################################################
+# !!!!!!!!!!!!!!!!!!!!!! IMPORTANT KEEP CAR AWAKE CHANGES !!!!!!!!!!!!!!!!!!!!!!
 #
-# Recent car firmware turns off USB ports very shortly after you get out of
-# the car, and changes to the Tesla API make it impossible for TeslaUSB to
-# keep the car awake or turn on Sentry mode in order to keep the USB ports
-# powered. This means that to keep the USB ports powered so that TeslaUSB
-# can finish archiving you need to turn on Sentry mode manually using the
-# Tesla app (or have it enabled by default for your home location).
-# Turning on Camp mode keeps the USB ports powered as well, but turns on
-# climate control which uses a lot of power.
-# If you turn on Sentry or Camp mode manually, you should probably set up
-# one of the notification mechanisms (see above) to let you know when
-# archiving finishes, so you can remember to turn Sentry/Camp mode off again.
-# It has been reported that some car models keep the USB ports powered
-# while the car is charging.
-# You could also consider using a power bank or UPS hat to keep TeslaUSB
-# powered independent of the power state of the car's USB ports. See the
-# TeslaUSB wiki for more info.
+# Recent car firmware turns off USB ports shortly after you exit the car,
+# affecting the ability for TeslaUSB to finish archiving. Sending ‘wake’ or
+# ‘Sentry On’ command through (unofficial) Tesla API, and by extension TeslaFi,
+# or Tessie, were ways to keep the car alive. The unofficial Tesla API is now
+# deprecated with the launch of the official Tesla Fleet API (a paid service
+# for 3rd-party developers). While TeslaFi and Tessie will continue to work,
+# the ability to leverage ‘wake’ command is no longer realistic (only 25 wake
+# calls per month are allowed without additional cost). Some adjustments need
+# to be made for TeslaFi and Tessie subscribers. Please read those sections
+# carefully.
 #
-# It may also be possible to use Tessie or TeslaFi to keep the USB ports
-# powered (both are paid services) by defining the variables below.
+# Other ways to keep the USB ports powered for TeslaUSB to finish archiving
+# involves manually turning on Sentry Mode or Camp Mode from the Tesla App.
+# However, neither are great solutions as they keep the car on indefinitely,
+# thus unnecessarily consuming the car’s high-voltage battery. For that reason,
+# it’s a good idea to setup notification mechanisms (see preceeding sections) so
+# you know when to manually turn Off Sentry/Camp Mode from the Tesla App.
 #
-# IMPORTANT: Only ONE API should be used at the same time. 
-# Do not include API tokens for both TeslaFi and Tessie.
+# Another alternative is using a power bank or UPS hat to keep TeslaUSB powered
+# independent of the power state of the car's USB ports. See the TeslaUSB wiki
+# for more info.
+#
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+# TeslaFi and Tessie users, define the variables below according to your
+# Sentry Mode use case. Check your in-car settings menu: Safety -> Sentry Mode.
+#
+# Case 1: You want Sentry Mode On everywhere, except when parked safely at home.
 # 
-# How to generate TeslaFi API Tokens
-# GENERATE/REVOKE TESLAFI API TOKEN: Log into your TeslaFi account.
-#   Navigate to Settings -> Tesla API -> API Token (tab)
+#         !!! IMPORTANT: Verify your in-car Sentry Mode setting is set to ON
+#                        and uncheck 'Exclude Home'.
+# 
+#         Upon arriving home, Sentry Mode will remain ON to power TeslaUSB
+#         through archiving. Once archiving completes, a command will be sent
+#         to turn OFF Sentry Mode, thus allowing the car to go back to sleep.
+#         Whenever you leave home, Sentry will re-arm itself by default.
 #
-# ENABLE/DISABLE TESLAFI API COMMANDS: Verify the 'Resume Polling' (wake)
-#   command is enabled. Do not confused this with the 'Wake Vehicle' command.
-#   Navigate to Settings -> Tesla API -> Commands (tab)
+# Case 2: You don't want Sentry Mode anywhere, unless archiving.
+#
+#         !!! IMPORTANT: Verify your in-car Sentry Mode setting is set to OFF.
+#
+#         Upon arriving home, TeslaUSB will send a command to turn ON Sentry
+#         Mode. Once archiving completes, a command will be sent to turn OFF
+#         Sentry Mode, thus allow the car to go back to sleep.
+#         Whenever you leave home, Sentry will not re-arm itself by default. 
+#
+#export SENTRY_CASE=1
+#
+# Additional Tessie & TeslaFi Requirements:
+#
+# !!! IMPORTANT: Only ONE API should be used at a time. 
+#                Do not include API tokens for both TeslaFi and Tessie.
+# 
+# How to generate TeslaFi API Tokens:
+#   Log into your TeslaFi account.
+#   Navigate to Settings -> Tesla API -> API Token (tab).
+#
+# Enable TeslaFi API Command:
+#   Navigate to Settings -> Tesla API -> Commands (tab).
+#   Verify 'Sentry Mode' command is checked (enabled).
 #
 # How to generate Tessie API Tokens
-# GENERATE/REVOKE TESSIE API TOKEN: Log into your Tessie account.
-#   Navigate to Settings -> Developer API -> Generate access token
+#   Log into your Tessie account.
+#   Navigate to Settings -> Developer API -> Generate access token.
+#export TESLAFI_API_TOKEN='YOUR_TESLAFI_API_TOKEN_GOES_HERE'
+#export TESSIE_API_TOKEN='YOUR_TESSIE_API_TOKEN_GOES_HERE'
 #
-# export TESLAFI_API_TOKEN='YOUR_TESLAFI_API_TOKEN_GOES_HERE'
-# export TESSIE_API_TOKEN='YOUR_TESSIE_API_TOKEN_GOES_HERE'
-#
-# TESSIE API ONLY (Do not configure if using TeslaFi API):
-# The Tessie API requires the vehicle's VIN number to issue commands to it,
-# regardless of whether you only have one vehicle on the account or not.
-# export TESSIE_VIN=5YJ3E1EA4JF000001
-############################################################################
+# Tessie API ONLY (Do not configure if using TeslaFi API):
+#   The Tessie API requires the vehicle's VIN number to issue commands to it,
+#   regardless of whether you only have one vehicle on the account or not.
+#export TESSIE_VIN=5YJ3E1EA4JF000001
+################################################################################
 
 
 # Uncomment if you want to increase the size of the root

--- a/run/awake_start
+++ b/run/awake_start
@@ -1,43 +1,32 @@
 #!/bin/bash -eu
 
-if [[ ( ( ! -x /root/bin/tesla_api.py) || ( ! -s /mutable/cache.json ) ) && ( -z "${TESLAFI_API_TOKEN:+x}" ) && ( -z "${TESSIE_API_TOKEN:+x}" ) ]]
+if [[ ( -z "${TESLAFI_API_TOKEN:+x}" ) && ( -z "${TESSIE_API_TOKEN:+x}" ) ]]
 then
-  log "Not keeping car awake."
-  exit
-fi
-
-function ping {
-  while true
-  do
-    if [[ ( -n "${TESLA_REFRESH_TOKEN:+x}" ) ]]
-    # Use Tesla API to keep car awake
-    then
-      if timeout 10 /root/bin/tesla_api.py streaming_ping
+  log "Not keeping car awake using Sentry Mode via TeslaFi or Tessie."
+else
+  case "${SENTRY_CASE}" in
+    1)
+      # Sentry Mode should already be enabled
+      log "TeslaFi/Tessie: Skip sending command to enable Sentry Mode."
+      ;;
+    2)
+      if [[ ( -n "${TESLAFI_API_TOKEN:+x}" ) ]]
+      # Use TeslaFi API to enable Sentry Mode
       then
-        sleep 90
-      else
-        log "Failed to contact car using Tesla API, retrying in 5s..."
-        sleep 5
+        curl -s -H "Authorization: Bearer $TESLAFI_API_TOKEN" "https://www.teslafi.com/feed.php?command=set_sentry_mode&sentryMode=true&noWake=true"
+        log "TeslaFi: Command sent to enable Sentry Mode."
       fi
-    fi
 
-    if [[ ( -n "${TESLAFI_API_TOKEN:+x}" ) ]]
-    # Use TeslaFi API to keep car awake.
-    then
-      curl -s -H "Authorization: Bearer $TESLAFI_API_TOKEN" "https://www.teslafi.com/feed.php?command=wake_up"
-      # No need to contact TeslaFi too often to prevent API lockout (max 3 calls/min).
-      sleep 600
-    fi
-
-    if [[ -n "${TESSIE_API_TOKEN:+x}" ]]
-    # Use Tessie API to keep car awake
-    then
+      if [[ -n "${TESSIE_API_TOKEN:+x}" ]]
+      # Use Tessie API to enable Sentry Mode
+      then
         http_response=$(curl -s -w "%{http_code}" \
-            -H "Authorization: Bearer $TESSIE_API_TOKEN" \
-            -H "Accept: application/json" \
-            -H "User-Agent: github.com/marcone/teslausb" \
-            "https://api.tessie.com/$TESSIE_VIN/wake")
-        
+          -H "Authorization: Bearer $TESSIE_API_TOKEN" \
+          -H "Accept: application/json" \
+          -H "User-Agent: github.com/marcone/teslausb" \
+          "https://api.tessie.com/$TESSIE_VIN/command/enable_sentry")
+              
+        log "Tessie: Command sent to enable Sentry Mode."
         # Extract HTTP status code
         http_status="${http_response: -3}"
         
@@ -47,48 +36,26 @@ function ping {
         # Check if HTTP status code is not 200 (OK)
         if [ "$http_status" != "200" ]
         then
-            # Log an error
-            log "Failed to wake car with Tessie API. Check your TESSIE_API_TOKEN and TESSIE_VIN are set correctly. If they are, your car may not have a good connection. Retrying in 1 minute..."
-            sleep 60
+          # Log an error
+          log "Tessie: Failed to set Sentry Mode. Check your TESSIE_API_TOKEN and TESSIE_VIN are set correctly. If they are, your car may not have a good connection."
         else
-            # Check if the response is in JSON format
-            if ! jq -e . >/dev/null 2>&1 <<<"$response_body"
+          # Check if the response is in JSON format
+          if ! jq -e . >/dev/null 2>&1 <<<"$response_body"
+          then
+            log "Tessie: Failed to set Sentry Mode. Response data: $response_body"
+          else
+            # Parse JSON and check if "result" is true
+            result=$(jq -r '.result' <<<"$response_body")
+            if [[ "$result" != "true" ]]
             then
-                log "Failed to wake car with Tessie API. Retrying in 1 minute. Response data: $response_body"
-                sleep 60
-            else
-                # Parse JSON and check if "result" is true
-                result=$(jq -r '.result' <<<"$response_body")
-                if [[ "$result" != "true" ]]
-                then
-                    log "Failed to wake car with Tessie API. Retrying in 1 minute. Response data: $response_body"
-                    sleep 60
-                else
-                    # Sleep for 5 minutes on successful wake-up call
-                    sleep 300
-                fi
+              log "Tessie: Failed to set Sentry Mode. Response data: $response_body"
             fi
+          fi
         fi
-    fi
-  done
-}
-
-case "${TESLA_WAKE_MODE:-stream}" in
-  sentry)
-    is_sentry_mode_enabled=$(/root/bin/tesla_api.py is_sentry_mode_enabled | tr '[:upper:]' '[:lower:]')
-    if [ "false" = "${is_sentry_mode_enabled}" ]
-    then
-      log "Temporarily enabling Sentry Mode to keep car awake."
-      touch /tmp/disable_sentry_after_archiving
-      /root/bin/tesla_api.py enable_sentry_mode &>> "${LOG_FILE}"
-    fi
-    ;;
-  stream)
-    log "Starting background task to keep car awake."
-    ping &
-    echo $! > /tmp/keep_awake_task_pid
-    ;;
-  *)
-    log "Unknown TESLA_WAKE_MODE: ${TESLA_WAKE_MODE}."
-    ;;
-esac
+      fi
+      ;;
+    *)
+      log "Invalid or no SENTRY_CASE defined."
+      ;;
+  esac
+fi

--- a/run/awake_stop
+++ b/run/awake_stop
@@ -1,28 +1,45 @@
 #!/bin/bash -eu
 
-if [[ ( ( ! -x /root/bin/tesla_api.py) || ( ! -s /mutable/cache.json ) ) && ( -z "${TESLAFI_API_TOKEN:+x}" ) && ( -z "${TESSIE_API_TOKEN:+x}" ) ]]
+if [[ ( -n "${TESLAFI_API_TOKEN:+x}" ) ]]
+# Use TeslaFi API to disable Sentry Mode
 then
-  exit
+  curl -s -H "Authorization: Bearer $TESLAFI_API_TOKEN" "https://www.teslafi.com/feed.php?command=set_sentry_mode&sentryMode=false&noWake=true"
+  log "TeslaFi: Command sent to disable Sentry Mode."
 fi
 
-# If Sentry Mode was previously disabled, restore it to that state
-if [ -e /tmp/disable_sentry_after_archiving ]
+if [[ -n "${TESSIE_API_TOKEN:+x}" ]]
+# Use Tessie API to disable Sentry Mode
 then
-  log "Restoring Sentry Mode to its previous state (disabled)..."
-  /root/bin/tesla_api.py disable_sentry_mode &>> "${LOG_FILE}"
-  rm -f /tmp/disable_sentry_after_archiving
-fi
+  http_response=$(curl -s -w "%{http_code}" \
+    -H "Authorization: Bearer $TESSIE_API_TOKEN" \
+    -H "Accept: application/json" \
+    -H "User-Agent: github.com/marcone/teslausb" \
+    "https://api.tessie.com/$TESSIE_VIN/command/disable_sentry")
 
-if [ -e /tmp/keep_awake_task_pid ]
-then
-  log "Stopping wake car background task."
-  kill "$(cat /tmp/keep_awake_task_pid)" || true
-  rm -f /tmp/keep_awake_task_pid
+  log "Tessie: Command sent to disable Sentry Mode."
+  # Extract HTTP status code
+  http_status="${http_response: -3}"
+          
+  # Extract response body (excluding status code)
+  response_body="${http_response:0:${#http_response}-3}"
 
-  if [[ ( -n "${TESLAFI_API_TOKEN:+x}" ) ]]
-  # TeslaFi Sleep command suspends its polling for the next 15 minutes (by default) to faciliate car's sleep.
+  # Check if HTTP status code is not 200 (OK)
+  if [ "$http_status" != "200" ]
   then
-    curl -H "Authorization: Bearer $TESLAFI_API_TOKEN" "https://www.teslafi.com/feed.php?command=sleep"
-    log "also initiated TeslaFi Sleep Mode to give the car a chance to fall asleep." 
+    # Log an error
+    log "Tessie: Failed to set Sentry Mode. Check your TESSIE_API_TOKEN and TESSIE_VIN are set correctly. If they are, your car may not have a good connection."
+  else
+    # Check if the response is in JSON format
+    if ! jq -e . >/dev/null 2>&1 <<<"$response_body"
+    then
+      log "Tessie: Failed to set Sentry Mode. Response data: $response_body"
+    else
+      # Parse JSON and check if "result" is true
+      result=$(jq -r '.result' <<<"$response_body")
+      if [[ "$result" != "true" ]]
+      then
+        log "Tessie: Failed to set Sentry Mode. Response data: $response_body"
+      fi
+    fi
   fi
 fi

--- a/setup/pi/configure.sh
+++ b/setup/pi/configure.sh
@@ -178,58 +178,10 @@ function pip3_install () {
   pip3 install "$@"
 }
 
-function install_and_configure_tesla_api () {
-  # Install the tesla_api.py script only if the user provided credentials for its use.
-
-  if [ -e /root/bin/tesla_api.py ]
-  then
-    # if tesla_api.py already exists, update it
-    log_progress "Updating tesla_api.py"
-    copy_script run/tesla_api.py /root/bin
-    install_python3_pip
-    pip3_install teslapy
-    # check if the json file needs to be updated
-    readonly json=/mutable/tesla_api.json
-    if [ -e $json ] && ! grep -q '"id"' $json
-    then
-      log_progress "Updating tesla_api.py config file"
-      sed -i 's/"vehicle_id"/"id"/' $json
-      sed -i 's/"$/",\n  "vehicle_id": 0/' $json
-      # Call script to fill in the empty vehicle_id field
-      if ! /root/bin/tesla_api.py list_vehicles
-      then
-        log_progress "tesla_api.py config update failed"
-      fi
-    fi
-  elif [[ ( -n "${TESLA_REFRESH_TOKEN:+x}" ) ]]
-  then
-    log_progress "Installing tesla_api.py"
-    copy_script run/tesla_api.py /root/bin
-    install_python3_pip
-    pip3_install teslapy
-    # Perform the initial authentication
-    mount /mutable || log_progress "Failed to mount /mutable"
-    if ! /root/bin/tesla_api.py list_vehicles
-    then
-      log_progress "tesla_api.py setup failed"
-    fi
-  else
-    log_progress "Skipping tesla_api.py install because no Tesla credentials were provided."
-  fi
-}
-
 function check_teslafi_api () {
   if [[ ( -n "${TESLAFI_API_TOKEN:+x}" ) ]]
   then
-    if [[ ( -n "${TESLA_REFRESH_TOKEN:+x}" ) ]]
-    then
-      log_progress "STOP: You're trying to setup Tesla and TeslaFi APIs at the same time."
-      log_progress "Only 1 can be enabled at a time."
-    elif [[ ( -n "${TESLA_WAKE_MODE:+x}" ) ]]    
-    then
-      log_progress "STOP: You've setup for TeslaFi API, yet you've specified a parameter for Tesla API."
-      log_progress "Please comment out TESLA_WAKE_MODE."
-    elif [[ ( -n "${TESSIE_API_TOKEN:+x}" ) ]]    
+    if [[ ( -n "${TESSIE_API_TOKEN:+x}" ) ]]    
     then
       log_progress "STOP: You're trying to setup Tessie and TeslaFi APIs at the same time."
       log_progress "Only 1 can be enabled at a time."
@@ -244,15 +196,7 @@ function check_teslafi_api () {
 function check_tessie_api () {
   if [[ ( -n "${TESSIE_API_TOKEN:+x}" ) ]]
   then
-    if [[ ( -n "${TESLA_REFRESH_TOKEN:+x}" ) ]]
-    then
-      log_progress "STOP: You're trying to setup Tesla and Tessie APIs at the same time."
-      log_progress "Only 1 can be enabled at a time."
-    elif [[ ( -n "${TESLA_WAKE_MODE:+x}" ) ]]    
-    then
-      log_progress "STOP: You've setup for Tessie API, yet you've specified a parameter for Tesla API."
-      log_progress "Please comment out TESLA_WAKE_MODE."
-    elif [[ ( -n "${TESLAFI_API_TOKEN:+x}" ) ]]    
+    if [[ ( -n "${TESLAFI_API_TOKEN:+x}" ) ]]    
     then
       log_progress "STOP: You're trying to setup Tessie and TeslaFi APIs at the same time."
       log_progress "Only 1 can be enabled at a time."
@@ -285,7 +229,6 @@ function install_archive_scripts () {
   copy_script run/remountfs_rw "$install_path"
   copy_script run/awake_start "$install_path"
   copy_script run/awake_stop "$install_path"
-  install_and_configure_tesla_api
   log_progress "Installing archive module scripts"
   copy_script "$archive_module"/verify-and-configure-archive.sh /tmp
   copy_script "$archive_module"/archive-clips.sh "$install_path"


### PR DESCRIPTION
Sentry Mode is now the only viable API method for keeping the car awake during archiving.
`awake_start` & `awake_stop` have been rewritten and any legacy/Tesla API related codes have been removed.
New parameter required: `SENTRY_CASE`
See updated description in `.conf` file for additional details.

Legacy method of keeping track of previous Sentry Mode state is no longer relevant nor necessary. The general mode of operation can be far simpler and broken into the following 3 scenarios:

Case 0: Those who prefer to have Sentry Mode ON anywhere.
No special actions is required from TeslaUSB. With Sentry Mode always ON, TeslaUSB will be consistently powered and able to complete the archive without interruptions.

Case 1: Those who prefer to have Sentry Mode ON anywhere, except Home.
This is the case for me. I don't use Sentry Mode when the car is safely parked inside an enclosed garage.
Sentry Mode must be set to ON in-car and DO NOT select 'Exclude Home' (counter intuitive).
No special actions for TeslaUSB before archiving, since Sentry will already have been ON when first arriving home.
Sentry OFF is executed when archive completes to allow the car to fall asleep.
Whenever the car leaves home, Sentry Mode will automatically default back to ON per the in-car setting.

Case 2: Those who prefer to have Sentry Mode OFF anywhere.
Sentry Mode must be set to OFF in-car. 
Right before archiving, TeslaUSB will execute a Sentry Mode ON command.
Sentry OFF is executed when archive completes to allow the car to fall asleep.
Whenever the car leaves home, Sentry Mode will continue to be OFF per the in-car setting.