### PR TITLE
www: firefox requires this preload flag on video tags to play

### DIFF
--- a/teslausb-www/html/index.html
+++ b/teslausb-www/html/index.html
@@ -917,20 +917,20 @@ video {
       </div>
       <div>
         <div class="videoholder layout3">
-          <video disableRemotePlayback playsinline id="leftview" class="videogriditem leftview" style="z-index:1;"></video>
+          <video preload="" disableRemotePlayback playsinline id="leftview" class="videogriditem leftview" style="z-index:1;"></video>
           <canvas id="leftviewfreeze" class="videogriditem leftview"  style="z-index:0;"></canvas>
 
-          <video disableRemotePlayback playsinline id="frontview" class="videogriditem frontview" style="z-index:1;"></video>
+          <video preload="" disableRemotePlayback playsinline id="frontview" class="videogriditem frontview" style="z-index:1;"></video>
           <canvas id="frontviewfreeze" class="videogriditem frontview" style="z-index:0;"></canvas>
 
-          <video disableRemotePlayback playsinline id="rightview" class="videogriditem rightview" style="z-index:1;"></video>
+          <video preload="" disableRemotePlayback playsinline id="rightview" class="videogriditem rightview" style="z-index:1;"></video>
           <canvas id="rightviewfreeze" class="videogriditem rightview" style="z-index:0;"></canvas>
 
           <div class="videogriditem mapview" style="margin:0px;z-index:0;">
             <iframe id="sentrymap"></iframe>
           </div>
 
-          <video disableRemotePlayback playsinline id="backview" class="videogriditem backview" style="z-index:1;"></video>
+          <video preload="" disableRemotePlayback playsinline id="backview" class="videogriditem backview" style="z-index:1;"></video>
           <canvas id="backviewfreeze" class="videogriditem backview" style="z-index:0;"></canvas>
 
           <div id="infoholder" class="videogriditem infoview" style="margin-left:12px;color:white;">


### PR DESCRIPTION
otherwise it's blank where the videos are supposed to be.

User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:134.0) Gecko/20100101 Firefox/134.0

problem solved, ready to be merged.