### PR TITLE
Configurable free space reserve

### DIFF
--- a/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
+++ b/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
@@ -95,6 +95,12 @@ export CAM_SIZE=40G
 #export LIGHTSHOW_SIZE=1G
 #export BOOMBOX_SIZE=100M
 
+# Configure free space, default equal to 10GiB plus three percent of
+# the total available space. This should be enough to hold the next hour
+# of recordings without completely filling up the filesystem.
+# Configured in "bytes"
+#export RESERVE_SIZE=10737418240
+
 # If you want to automatically copy music from a CIFS share every time
 # the Pi connects to wifi, set the following variable. The share is
 # assumed to exist on the same server as the archive share. It can

--- a/run/archiveloop
+++ b/run/archiveloop
@@ -753,7 +753,7 @@ function snapshotloop {
 function freespacemanager {
   echo -n freespacemanager > /proc/self/comm
   # 10G
-  local reserve=10737418240
+  local reserve="${RESERVE_SIZE:-10737418240}"
   local threepctoftotalspace
   threepctoftotalspace=$(eval "$(stat --file-system --format="echo \$((%b*%S/33))" /backingfiles/cam_disk.bin)")
   reserve=$((reserve+threepctoftotalspace))


### PR DESCRIPTION
Make free space reserve configurable. Default 10GiB + 3% of total available is ideal for "small" SD card, but can cause higher wear level on large SSD.
I'm using 1TB NVMe and would like to leave 100GiB free.