### PR TITLE
Update archiveloop: Log temperatures

### DIFF
--- a/run/archiveloop
+++ b/run/archiveloop
@@ -687,7 +687,7 @@ function archive_clips () {
     log "Archiving failed."
   fi
 
-  log "$(vcgencmd measure_temp)"
+  log_coretemp
 
   if timeout 5 [ -d "$MUSIC_ARCHIVE_MOUNT" -a -d "$MUSIC_MOUNT" ]
   then
@@ -702,7 +702,7 @@ function archive_clips () {
     log "Music archive not configured or unreachable"
   fi
 
-  log "$(vcgencmd measure_temp)"
+  log_coretemp
 
   /root/bin/disconnect-archive.sh
 }
@@ -751,7 +751,7 @@ function snapshotloop {
     sleep "${SNAPSHOT_INTERVAL:-3480}"
     /root/bin/waitforidle || true
     /root/bin/make_snapshot.sh
-    log "$(vcgencmd measure_temp)"
+    log_coretemp
   done
 }
 
@@ -843,6 +843,13 @@ function set_sys_param() {
   fi
 }
 
+function log_coretemp() {
+  local core_temp=$(cat /sys/class/thermal/thermal_zone0/temp)
+  local core_temp1=$((core_temp / 1000))
+  local core_temp2=$((core_temp % 1000))
+  log "Core Temperature = ${core_temp1}.${core_temp2} °C"
+}
+
 export -f mount_mountpoint
 export -f ensure_mountpoint_is_mounted
 export -f retry
@@ -856,7 +863,7 @@ set_sys_param /proc/sys/vm/dirty_background_bytes DIRTY_BACKGROUND_BYTES 65536
 set_sys_param /proc/sys/vm/dirty_ratio DIRTY_RATIO 80
 set_sys_param /sys/devices/system/cpu/cpufreq/policy0/scaling_governor CPU_GOVERNOR conservative
 
-log "$(vcgencmd measure_temp)"
+log_coretemp
 
 if has_cam_disk
 then

--- a/run/archiveloop
+++ b/run/archiveloop
@@ -633,9 +633,7 @@ function archive_teslacam_clips () {
       cat /tmp/archive-error.log >> ${LOG_FILE}
       rm /tmp/archive-error.log
     fi
-
-    log $(vcgencmd measure_temp)
-
+    log "$(vcgencmd measure_temp)"
   fi
 
   # overlayfs behavior is undefined if the lower is changed while the overlay is active, so umount first
@@ -750,7 +748,7 @@ function snapshotloop {
     sleep "${SNAPSHOT_INTERVAL:-3480}"
     /root/bin/waitforidle || true
     /root/bin/make_snapshot.sh
-    log $(vcgencmd measure_temp)
+    log "$(vcgencmd measure_temp)"
   done
 }
 
@@ -855,7 +853,7 @@ set_sys_param /proc/sys/vm/dirty_background_bytes DIRTY_BACKGROUND_BYTES 65536
 set_sys_param /proc/sys/vm/dirty_ratio DIRTY_RATIO 80
 set_sys_param /sys/devices/system/cpu/cpufreq/policy0/scaling_governor CPU_GOVERNOR conservative
 
-log $(vcgencmd measure_temp)
+log "$(vcgencmd measure_temp)"
 
 if has_cam_disk
 then

--- a/run/archiveloop
+++ b/run/archiveloop
@@ -633,6 +633,9 @@ function archive_teslacam_clips () {
       cat /tmp/archive-error.log >> ${LOG_FILE}
       rm /tmp/archive-error.log
     fi
+
+    log $(vcgencmd measure_temp)
+
   fi
 
   # overlayfs behavior is undefined if the lower is changed while the overlay is active, so umount first
@@ -747,6 +750,7 @@ function snapshotloop {
     sleep "${SNAPSHOT_INTERVAL:-3480}"
     /root/bin/waitforidle || true
     /root/bin/make_snapshot.sh
+    log $(vcgencmd measure_temp)
   done
 }
 
@@ -850,6 +854,8 @@ log "Starting archiveloop at $(awk '{print $1}' /proc/uptime) seconds uptime..."
 set_sys_param /proc/sys/vm/dirty_background_bytes DIRTY_BACKGROUND_BYTES 65536
 set_sys_param /proc/sys/vm/dirty_ratio DIRTY_RATIO 80
 set_sys_param /sys/devices/system/cpu/cpufreq/policy0/scaling_governor CPU_GOVERNOR conservative
+
+log $(vcgencmd measure_temp)
 
 if has_cam_disk
 then

--- a/run/archiveloop
+++ b/run/archiveloop
@@ -633,7 +633,6 @@ function archive_teslacam_clips () {
       cat /tmp/archive-error.log >> ${LOG_FILE}
       rm /tmp/archive-error.log
     fi
-    log "$(vcgencmd measure_temp)"
   fi
 
   # overlayfs behavior is undefined if the lower is changed while the overlay is active, so umount first
@@ -688,6 +687,8 @@ function archive_clips () {
     log "Archiving failed."
   fi
 
+  log "$(vcgencmd measure_temp)"
+
   if timeout 5 [ -d "$MUSIC_ARCHIVE_MOUNT" -a -d "$MUSIC_MOUNT" ]
   then
     log "Copying music..."
@@ -701,7 +702,9 @@ function archive_clips () {
     log "Music archive not configured or unreachable"
   fi
 
-  /root/bin/disconnect-archive.sh
+  log "$(vcgencmd measure_temp)"
+
+/root/bin/disconnect-archive.sh
 }
 
 function slowblink () {

--- a/run/archiveloop
+++ b/run/archiveloop
@@ -704,7 +704,7 @@ function archive_clips () {
 
   log "$(vcgencmd measure_temp)"
 
-/root/bin/disconnect-archive.sh
+  /root/bin/disconnect-archive.sh
 }
 
 function slowblink () {

--- a/run/archiveloop
+++ b/run/archiveloop
@@ -844,9 +844,13 @@ function set_sys_param() {
 }
 
 function log_coretemp() {
-  local core_temp=$(cat /sys/class/thermal/thermal_zone0/temp)
-  local core_temp1=$((core_temp / 1000))
-  local core_temp2=$((core_temp % 1000))
+  local core_temp
+  local core_temp1
+  local core_temp2
+
+  core_temp=$(cat /sys/class/thermal/thermal_zone0/temp)
+  core_temp1=$((core_temp / 1000))
+  core_temp2=$((core_temp % 1000))
   log "Core Temperature = ${core_temp1}.${core_temp2} °C"
 }
 


### PR DESCRIPTION
Add temperature logging to provide the thermo profile of the SBC as it operates. It is event triggered so as not to cluttered the log. Triggers 1) shortly after boot-up, 2) after each snapshot (~1hr by default), and 3) after archiving.

[SampleLog.txt](https://github.com/user-attachments/files/20914940/SampleLog.txt)
