### PR TITLE
Archive Logs to Server (CIFS)

### DIFF
--- a/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
+++ b/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
@@ -25,9 +25,12 @@ export SHARE_NAME='your_archive_share/optional_path_on_share'
 export SHARE_USER=username
 export SHARE_PASSWORD='password'
 # the cifs options below usually don't need to be specified
-# export SHARE_DOMAIN=domain
-# export CIFS_VERSION="3.0"
-# export CIFS_SEC="ntlm"
+#export SHARE_DOMAIN=domain
+#export CIFS_VERSION="3.0"
+#export CIFS_SEC="ntlm"
+# Options to include archiveloop.log and rsync-music.log during archiving
+#export CIFS_ARCHIVE_LOG=true
+#export CIFS_MUSIC_LOG=true
 
 # Variables for rsync archiving
 # For instructions setting up SSH Public Key authentication, view:

--- a/run/cifs_archive/copy-music.sh
+++ b/run/cifs_archive/copy-music.sh
@@ -3,6 +3,7 @@
 SRC="/mnt/musicarchive"
 DST="/mnt/music"
 LOG="/tmp/rsyncmusiclog.txt"
+MLOG="/mutable/rsyncmusic.log"
 
 # check that DST is the mounted disk image, not the mountpoint directory
 if ! findmnt --mountpoint $DST > /dev/null
@@ -54,7 +55,11 @@ function do_music_sync {
 
   connectionmonitor $$ &
 
-  if ! rsync -rum --no-human-readable --exclude=.fseventsd/*** --exclude=*.DS_Store --exclude=.metadata_never_index \
+  echo -e "============================\n" \
+  $(date) \
+  "\n============================" >> "$MLOG"
+  
+  if ! rsync -rumv --no-human-readable --exclude=.fseventsd/*** --exclude=*.DS_Store --exclude=.metadata_never_index \
                 --exclude="System Volume Information/***" \
                 --delete --modify-window=2 --info=stats2 "$SRC/" "$DST" &> "$LOG"
   then
@@ -88,6 +93,12 @@ function do_music_sync {
   else
     log "$message"
   fi
+
+  tail -n 50000 "$MLOG" > /tmp/rsyncmusic.tmp && mv /tmp/rsyncmusic.tmp "$MLOG" 
+  cat "$LOG" >> "$MLOG"
+  log "Archiving rsyncmusic.log to the server"
+  cp -f "$MLOG" "$ARCHIVE_MOUNT"
+  cp -f /mutable/archiveloop.log "$ARCHIVE_MOUNT"
 }
 
 if ! do_music_sync

--- a/run/cifs_archive/copy-music.sh
+++ b/run/cifs_archive/copy-music.sh
@@ -96,9 +96,17 @@ function do_music_sync {
 
   tail -n 50000 "$MLOG" > /tmp/rsyncmusic.tmp && mv /tmp/rsyncmusic.tmp "$MLOG" 
   cat "$LOG" >> "$MLOG"
-  log "Archiving rsyncmusic.log & archiveloop.log to the server"
-  cp -f "$MLOG" "$ARCHIVE_MOUNT"
-  cp -f /mutable/archiveloop.log "$ARCHIVE_MOUNT"
+
+  if [ "$CIFS_MUSIC_LOG" = "true" ]
+  then
+    log "Archiving rsyncmusic.log to the server"
+    cp -f "$MLOG" "$ARCHIVE_MOUNT"
+  fi
+  if [ "$CIFS_ARCHIVE_LOG" = "true" ]
+  then
+     log "Archiving archiveloop.log to the server"
+    cp -f /mutable/archiveloop.log "$ARCHIVE_MOUNT"
+  fi
 }
 
 if ! do_music_sync

--- a/run/cifs_archive/copy-music.sh
+++ b/run/cifs_archive/copy-music.sh
@@ -96,7 +96,7 @@ function do_music_sync {
 
   tail -n 50000 "$MLOG" > /tmp/rsyncmusic.tmp && mv /tmp/rsyncmusic.tmp "$MLOG" 
   cat "$LOG" >> "$MLOG"
-  log "Archiving rsyncmusic.log to the server"
+  log "Archiving rsyncmusic.log & archiveloop.log to the server"
   cp -f "$MLOG" "$ARCHIVE_MOUNT"
   cp -f /mutable/archiveloop.log "$ARCHIVE_MOUNT"
 }


### PR DESCRIPTION
For CIFS only.
Generates a running log for music files sync'd.
Archives the `rsyncmusic.log` and `archiveloop.log` to the server (under the TeslaCam share) for easy access.
