### PR TITLE
add push message on completion of archive loop

### DIFF
--- a/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
+++ b/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
@@ -250,7 +250,7 @@ export CAM_SIZE=40G
 # TeslaUSB.
 #
 # In order to keep the car awake, several methods have been implemented:
-# TeslaFi, Tessie, and Bluetooth Low Energy (BLE). Please note that the previous
+# TeslaFi, Tessie, Bluetooth Low Energy (BLE), and Webhooks. Please note that the previous
 # implementation using the (unofficial) Tesla API was removed. Tesla had
 # superseded it with their official Fleet API (a paid service for developers).
 # Consequently, TeslaFi and Tessie now enforce request rate limits. As a result,
@@ -276,6 +276,12 @@ export CAM_SIZE=40G
 #     wifi/interenet connection to keep car alive.
 #   - Some security vulnerability
 #   - Requires paid 3rd-party service from TeslaFi or Tessie
+#
+# Webhook Pros/Cons:
+#   + Does not require teslausb to store credentials that can directly
+#     control your vehicle
+#   - Requires another service like home assistant be setup to receive
+#     webhooks and carry out the required actions to keep the vehicle awake
 #
 # DISCLAIMER:
 #   All 3 methods have some level of security implications. For BLE,
@@ -317,7 +323,7 @@ export CAM_SIZE=40G
 # compatibility notes. If applicable, also make a 1-time change (set and
 # forget) to your in-car menu: Safety -> Sentry Mode.
 #
-#  Case 1: [Compatible with TeslaFi, Tessie, or BLE]
+#  Case 1: [Compatible with TeslaFi, Tessie, BLE, or Webhook]
 #
 #          You want Sentry Mode turned On everywhere, except when parked safely
 #          at home. Upon arriving home, Sentry Mode will already be ON
@@ -329,7 +335,7 @@ export CAM_SIZE=40G
 #     >>>> IMPORTANT: Verify your in-car Sentry Mode is set to ON, and
 #                     'Exclude Home' is UNCHECKED.
 #
-#  Case 2: [Compatible with TeslaFi, Tessie, or BLE]
+#  Case 2: [Compatible with TeslaFi, Tessie, BLE, or Webhook]
 #
 #          You DON'T want Sentry Mode turned on anywhere, unless archiving.
 #          Mode of operation: Upon arriving home, TeslaUSB will send a command
@@ -340,7 +346,7 @@ export CAM_SIZE=40G
 #
 #     >>>> IMPORTANT: Verify your in-car Sentry Mode is set to OFF.
 #
-#  Case 3: [Compatible with Tessie or BLE]
+#  Case 3: [Compatible with Tessie, BLE, or Webhook]
 #
 #          Sentry Mode is not used by TeslaUSB. Instead a periodic command is
 #          sent to the car to keep it awake.
@@ -393,6 +399,16 @@ export CAM_SIZE=40G
 #        Note: This does not prevent the car from locking, nor does it allow
 #        someone to readily unlock or drive the car. An authroized key (card,
 #        phone, fob) is still required.
+# .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .
+#
+# For webhook, provide the URL of the webhook that will receive awake messages:
+#export KEEP_AWAKE_WEBHOOK_URL=http://domain/path
+#
+#   A webhook message with a JSON body will be sent. The shape of the JSON will be { "awake_command": "<command>" }
+#   Commands that will be sent to this webook:
+#     1. start: Sent when SENTRY_CASE=2 and the archive process starts
+#     2. stop: Sent when SENTRY_CASE=1 or 2 and the archive process stops
+#     3. nudge: Sent when SENTRY_CASE=3 and the archive process is ongoing
 ################################################################################
 
 # Temperature Monitor

--- a/run/archiveloop
+++ b/run/archiveloop
@@ -692,10 +692,6 @@ function archive_clips () {
   /root/bin/disconnect-archive.sh
 }
 
-function send_loop_completion () {
-  /root/bin/send-push-message "$NOTIFICATION_TITLE:" "archive loop finished" || log "failed to send push message: archive loop finished"
-}
-
 function slowblink () {
   echo timer > "$STATUSLED/trigger" || return 0
   echo 900 > "$STATUSLED/delay_off"
@@ -881,8 +877,6 @@ then
 
   connect_usb_drives_to_host
 
-  send_loop_completion
-
   wait_for_archive_to_be_unreachable
 fi
 
@@ -913,8 +907,6 @@ do
   doubleblink
 
   connect_usb_drives_to_host
-
-  send_loop_completion
 
   wait_for_archive_to_be_unreachable
 

--- a/run/archiveloop
+++ b/run/archiveloop
@@ -692,6 +692,10 @@ function archive_clips () {
   /root/bin/disconnect-archive.sh
 }
 
+function send_loop_completion () {
+  /root/bin/send-push-message "$NOTIFICATION_TITLE:" "archive loop finished" || log "failed to send push message: archive loop finished"
+}
+
 function slowblink () {
   echo timer > "$STATUSLED/trigger" || return 0
   echo 900 > "$STATUSLED/delay_off"
@@ -877,6 +881,8 @@ then
 
   connect_usb_drives_to_host
 
+  send_loop_completion
+
   wait_for_archive_to_be_unreachable
 fi
 
@@ -907,6 +913,8 @@ do
   doubleblink
 
   connect_usb_drives_to_host
+
+  send_loop_completion
 
   wait_for_archive_to_be_unreachable
 

--- a/run/awake_start
+++ b/run/awake_start
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-if [[ ( -z "${TESLAFI_API_TOKEN:+x}" ) && ( -z "${TESSIE_API_TOKEN:+x}" ) && ( -z "${TESLA_BLE_VIN:+x}" ) ]]
+if [[ ( -z "${TESLAFI_API_TOKEN:+x}" ) && ( -z "${TESSIE_API_TOKEN:+x}" ) && ( -z "${TESLA_BLE_VIN:+x}" ) && ( -z "${KEEP_AWAKE_WEBHOOK_URL:+x}" ) ]]
 then
   log "Not configured to keep car awake."
 else
@@ -60,6 +60,26 @@ else
               break
             fi
           fi
+        fi
+
+      elif [[ -n "${KEEP_AWAKE_WEBHOOK_URL:+x}" ]]
+      # Use webhook to send nudge message
+      then
+        http_response=$(curl -s -w "%{http_code}" POST \
+          -d "{\"awake_command\":\"nudge\"}" \
+          -H "Content-Type: application/json" \
+          "$KEEP_AWAKE_WEBHOOK_URL")
+        
+        log "Awake Webhook: Command sent \"nudge\""
+
+        # Extract HTTP status code
+        http_status="${http_response: -3}"
+
+        # Check if HTTP status code is not 200 (OK)
+        if [ "$http_status" -lt 200 -o "$http_status" -ge 300  ]
+        then
+          # Log an error
+          log "Awake Webhook: Failed to send command \"nudge\". Check if your KEEP_AWAKE_WEBHOOK_URL is set correctly. If it is, check the service receiving webhooks for logs."
         fi
       fi
 
@@ -159,6 +179,25 @@ else
           log "Tesla BLE: Command sent to enable Sentry Mode."
         else
           log "Tesla BLE: Failed to set Sentry Mode."
+        fi
+      elif [[ -n "${KEEP_AWAKE_WEBHOOK_URL:+x}" ]]
+      # Use webhook to send start command
+      then
+        http_response=$(curl -s -w "%{http_code}" POST \
+          -d "{\"awake_command\":\"start\"}" \
+          -H "Content-Type: application/json" \
+          "$KEEP_AWAKE_WEBHOOK_URL")
+        
+        log "Awake Webhook: Command sent \"start\""
+
+        # Extract HTTP status code
+        http_status="${http_response: -3}"
+
+        # Check if HTTP status code is not 200 (OK)
+        if [ "$http_status" -lt 200 -o "$http_status" -ge 300  ]
+        then
+          # Log an error
+          log "Awake Webhook: Failed to send command \"start\". Check if your KEEP_AWAKE_WEBHOOK_URL is set correctly. If it is, check the service receiving webhooks for logs."
         fi
       fi
       ;;

--- a/run/awake_start
+++ b/run/awake_start
@@ -76,7 +76,7 @@ else
         http_status="${http_response: -3}"
 
         # Check if HTTP status code is not 200 (OK)
-        if [ "$http_status" -lt 200 -o "$http_status" -ge 300  ]
+        if [ "$http_status" -lt 200 ] || [ "$http_status" -ge 300 ]
         then
           # Log an error
           log "Awake Webhook: Failed to send command \"nudge\". Check if your KEEP_AWAKE_WEBHOOK_URL is set correctly. If it is, check the service receiving webhooks for logs."
@@ -194,7 +194,7 @@ else
         http_status="${http_response: -3}"
 
         # Check if HTTP status code is not 200 (OK)
-        if [ "$http_status" -lt 200 -o "$http_status" -ge 300  ]
+        if [ "$http_status" -lt 200 ] || [ "$http_status" -ge 300 ]
         then
           # Log an error
           log "Awake Webhook: Failed to send command \"start\". Check if your KEEP_AWAKE_WEBHOOK_URL is set correctly. If it is, check the service receiving webhooks for logs."

--- a/run/awake_stop
+++ b/run/awake_stop
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-if [[ ( -z "${TESLAFI_API_TOKEN:+x}" ) && ( -z "${TESSIE_API_TOKEN:+x}" ) && ( -z "${TESLA_BLE_VIN:+x}" ) ]]
+if [[ ( -z "${TESLAFI_API_TOKEN:+x}" ) && ( -z "${TESSIE_API_TOKEN:+x}" ) && ( -z "${TESLA_BLE_VIN:+x}" ) && ( -z "${KEEP_AWAKE_WEBHOOK_URL:+x}" ) ]]
 then
   exit
 fi
@@ -93,6 +93,26 @@ case "${SENTRY_CASE}" in
         log "Tesla BLE: Command sent to disable Sentry Mode."
       else
         log "Tesla BLE: Failed to set Sentry Mode."
+      fi
+
+    elif [[ -n "${KEEP_AWAKE_WEBHOOK_URL:+x}" ]]
+    # Use webhook to send stop message
+    then
+      http_response=$(curl -s -w "%{http_code}" POST \
+        -d "{\"awake_command\":\"stop\"}" \
+        -H "Content-Type: application/json" \
+        "$KEEP_AWAKE_WEBHOOK_URL")
+      
+      log "Awake Webhook: Command sent \"stop\""
+
+      # Extract HTTP status code
+      http_status="${http_response: -3}"
+
+      # Check if HTTP status code is not 200 (OK)
+      if [ "$http_status" -lt 200 -o "$http_status" -ge 300  ]
+      then
+        # Log an error
+        log "Awake Webhook: Failed to send command \"stop\". Check if your KEEP_AWAKE_WEBHOOK_URL is set correctly. If it is, check the service receiving webhooks for logs."
       fi
     fi
   ;;

--- a/run/awake_stop
+++ b/run/awake_stop
@@ -109,7 +109,7 @@ case "${SENTRY_CASE}" in
       http_status="${http_response: -3}"
 
       # Check if HTTP status code is not 200 (OK)
-      if [ "$http_status" -lt 200 -o "$http_status" -ge 300  ]
+      if [ "$http_status" -lt 200 ] || [ "$http_status" -ge 300 ]
       then
         # Log an error
         log "Awake Webhook: Failed to send command \"stop\". Check if your KEEP_AWAKE_WEBHOOK_URL is set correctly. If it is, check the service receiving webhooks for logs."

--- a/setup/pi/configure.sh
+++ b/setup/pi/configure.sh
@@ -181,7 +181,10 @@ function pip3_install () {
 function check_at_most_one_wake_api () {
   if [[ ( -n "${TESSIE_API_TOKEN:+x}" && -n "${TESLAFI_API_TOKEN:+x}" ) ||
         ( -n "${TESSIE_API_TOKEN:+x}" && -n "${TESLA_BLE_VIN:+x}" ) ||
-        ( -n "${TESLAFI_API_TOKEN:+x}" && -n "${TESLA_BLE_VIN:+x}" ) ]]
+        ( -n "${TESLAFI_API_TOKEN:+x}" && -n "${TESLA_BLE_VIN:+x}" ) ||
+        ( -n "${KEEP_AWAKE_WEBHOOK_URL:+x}" && -n "${TESLAFI_API_TOKEN:+x}" ) ||
+        ( -n "${KEEP_AWAKE_WEBHOOK_URL:+x}" && -n "${TESLA_BLE_VIN:+x}" ) ||
+        ( -n "${KEEP_AWAKE_WEBHOOK_URL:+x}" && -n "${TESSIE_API_TOKEN:+x}" )]]
   then
     log_progress "STOP: You're trying to set up multiple control providers at the same time."
     log_progress "Only 1 can be enabled at a time."
@@ -302,6 +305,21 @@ function check_and_configure_tesla_ble () {
     log_progress "Tesla BLE API enabled."
   else
     log_progress "Tesla BLE API not enabled because no Tesla BLE VIN was provided."
+  fi
+}
+
+function check_awake_webhook () {
+  if [[ ( -n "${KEEP_AWAKE_WEBHOOK_URL:+x}" ) ]]
+  then
+    check_variable "SENTRY_CASE"
+    if [[ "$SENTRY_CASE" != 1 && "$SENTRY_CASE" != 2 && "$SENTRY_CASE" != 3 ]]; then
+      log_progress "STOP: invalid SENTRY_CASE for Webhook."
+      exit 1
+    fi
+
+    log_progress "Awake Webhook enabled."
+  else
+    log_progress "Awake Webhook not enabled because no webhook URL was provided."
   fi
 }
 
@@ -757,6 +775,7 @@ then
   check_teslafi_api
   check_tessie_api
   check_and_configure_tesla_ble /root/bin
+  check_awake_webhook
 fi
 check_and_install_temperature_monitor /root/bin
 check_and_configure_pushover


### PR DESCRIPTION
Adds a push message that sends when the entire archive loop finishes.

I'm using webhooks to automate things when the archive process finishes but I'm running into issues when music sync is enabled. There's no webhook sent when music sync starts and there is only a message sent post music sync if there were files synced. In this case my automations think that teslausb is done working when it may still be syncing music.

If there's a better way to do this or a more preferred message I'm happy to make changes.