### PR TITLE
Fix "Pillars on Side" layout scaling on desktop

### DIFF
--- a/teslausb-www/html/index.html
+++ b/teslausb-www/html/index.html
@@ -236,6 +236,20 @@ iframe {
     color: #000;
     z-index:11;
   }
+
+  .navbar + div {
+    height: calc(100% - 50px);
+  }
+  .videoholder.layout6 {
+    grid-template-rows: minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr);
+    grid-template-columns: auto auto auto;
+    justify-content: center;
+  }
+  .videoholder.layout6 .videogriditem {
+    height: 100%;
+    width: auto;
+    max-width: 100%;
+  }
 }
 
 /*hide music tab by default */
@@ -1100,6 +1114,14 @@ function setLayout(layout) {
   var rightpillarview = document.getElementById("rightpillarview");
   var backview = document.getElementById("backview");
   var videogrid = document.querySelector(".videoholder");
+
+  /* Reset flipped status to ensure clean state for non-mirrored layouts (3, 5, 6) */
+  if (layout == 3 || layout == 5 || layout == 6) {
+    leftrepeaterview.classList.remove("flipped");
+    rightrepeaterview.classList.remove("flipped");
+    backview.classList.remove("flipped");
+  }
+  
   if (layout == 1) {
     // mirrorleft-front-mirrorright on top, map-mirrorrear-info on bottom
     leftrepeaterview.classList.add("flipped");
@@ -1120,9 +1142,6 @@ function setLayout(layout) {
     videogrid.classList="videoholder layout4";
   } else if (layout == 5) {
     // front on top, sides in middle, rear on bottom
-    leftrepeaterview.classList.remove("flipped");
-    rightrepeaterview.classList.remove("flipped");
-    backview.classList.remove("flipped");
     videogrid.classList="videoholder layout5";
   } else if (layout == 6) {
     // map-front-info on top, pillars on the side, repeaters and rear on bottom 
@@ -1130,9 +1149,6 @@ function setLayout(layout) {
   } else {
     layout = 3;
     // (default) map-front-info on top, right-rear-left on bottom
-    leftrepeaterview.classList.remove("flipped");
-    rightrepeaterview.classList.remove("flipped");
-    backview.classList.remove("flipped");
     videogrid.classList="videoholder layout3";
   }
   currentLayout = layout;
@@ -1146,6 +1162,30 @@ function setLayout(layout) {
     } else {
       item.classList.remove("selected");
     }
+  }
+  
+    if (typeof currentsequence !== 'undefined') {
+    setTimeout(function() {
+      for (var i=0; i < 6;i++) {
+        var v = videoelems[i];
+        var c = canvaselems[i];
+        
+        if (v.clientWidth > 0 && v.clientHeight > 0) {
+            c.width = v.clientWidth;
+            c.height = v.clientHeight;
+        }
+
+        if (v.style.visibility == "hidden") {
+           var ctx = c.getContext("2d");
+           if (v.classList.contains("flipped")) {
+             ctx.scale(-1, 1);
+             ctx.drawImage(v, 0, 0, -c.width, c.height);
+           } else {
+             ctx.drawImage(v, 0, 0, c.width, c.height);
+           }
+        }
+      }
+    }, 50);
   }
 }
 

--- a/teslausb-www/html/index.html
+++ b/teslausb-www/html/index.html
@@ -342,8 +342,8 @@ video {
 .videoholder.layout6 {
   grid-template-areas:
     "mapview frontview infoview"
-    "rightpillarview . leftpillarview"
-    "rightrepeaterview backview leftrepeaterview";
+    "leftpillarview . rightpillarview"
+    "leftrepeaterview backview rightrepeaterview";
 }
 
 .videogriditem {

--- a/teslausb-www/html/index.html
+++ b/teslausb-www/html/index.html
@@ -342,8 +342,8 @@ video {
 .videoholder.layout6 {
   grid-template-areas:
     "mapview frontview infoview"
-    "leftpillarview . rightpillarview"
-    "leftrepeaterview backview rightrepeaterview";
+    "rightpillarview . leftpillarview"
+    "rightrepeaterview backview leftrepeaterview";
 }
 
 .videogriditem {


### PR DESCRIPTION
Before:
<img width="2559" height="1318" alt="before" src="https://github.com/user-attachments/assets/4c19729c-ee83-47c9-99d0-58e48df2acba" />
After:
<img width="2559" height="1319" alt="after" src="https://github.com/user-attachments/assets/bed671f0-7fa0-4c4c-a16b-61b6bf4ec8aa" />

I've also swapped the camera positions, but if you prefer it wasn't changed I can revert that.