### PR TITLE
Add React UI and enable real-time music sync progress

### DIFF
--- a/run/cifs_archive/copy-music.sh
+++ b/run/cifs_archive/copy-music.sh
@@ -54,9 +54,10 @@ function do_music_sync {
 
   connectionmonitor $$ &
 
+  # --info=progress2 enables real-time progress output for web UI status display
   if ! rsync -rum --no-human-readable --exclude=.fseventsd/*** --exclude=*.DS_Store --exclude=.metadata_never_index \
                 --exclude="System Volume Information/***" \
-                --delete --modify-window=2 --info=stats2 "$SRC/" "$DST" &> "$LOG"
+                --delete --modify-window=2 --info=progress2,stats2 "$SRC/" "$DST" &> "$LOG"
   then
     log "rsync failed with error $?"
   fi

--- a/setup/pi/configure-web.sh
+++ b/setup/pi/configure-web.sh
@@ -45,7 +45,7 @@ fi
 # between Chrome and Tesla's recordings
 g++ -o /root/cttseraser -D_FILE_OFFSET_BITS=64 "$SOURCE_DIR/teslausb-www/cttseraser.cpp" -lstdc++ -lfuse
 
-# install new UI (compiled js/css files)
+# install new UI (compiled js/css files) - Vue UI at /new/
 curlwrapper -L -o /tmp/webui.tgz https://github.com/marcone/teslausb-webui/releases/latest/download/teslausb-ui.tgz
 tar -C /var/www/html -xf /tmp/webui.tgz
 if [ -d /var/www/html/new ] && ! [ -e /var/www/html/new/favicon.ico ]
@@ -53,6 +53,9 @@ then
   ln -s /var/www/html/favicon.ico /var/www/html/new/favicon.ico
 fi
 
+# install React UI at /react/ - alternative interface with real-time sync progress
+curlwrapper -L -o /tmp/reactui.tgz https://github.com/oaquique/teslausb-www-react/releases/latest/download/teslausb-react-ui.tgz
+tar -C /var/www/html -xf /tmp/reactui.tgz
 
 cat > /sbin/mount.ctts << EOF
 #!/bin/bash -eu


### PR DESCRIPTION
## Summary

This PR adds a third web interface option (React UI) alongside the existing Standard and Vue UIs, giving users more choice in how they interact with TeslaUSB.

- Install React UI at `/react/` from GitHub releases
- Enable real-time music sync progress output via rsync `--info=progress2`

## Changes

### 1. `setup/pi/configure-web.sh`
- Downloads and installs React UI tarball from [oaquique/teslausb-www-react](https://github.com/oaquique/teslausb-www-react/releases)
- Installs to `/var/www/html/react/` alongside existing UIs

### 2. `run/cifs_archive/copy-music.sh`
- Adds `progress2` to rsync `--info` flag
- Enables real-time progress output (bytes transferred, percentage, speed, ETA)
- Progress written to `/tmp/rsyncmusiclog.txt` (already used for stats)
- **No impact on existing functionality** - stats2 output remains unchanged
- Any web UI can now display live music sync progress

## React UI Features

- Real-time music sync progress display (percentage, speed, ETA)
- Modern responsive design optimized for mobile and desktop
- Per-drive storage visualization
- Built with Preact for minimal bundle size (~58KB JS, ~25KB CSS)
- Links to switch between all three UIs

## Access Points

After installation, users can access:
- **Standard UI**: `http://<pi-ip>/`
- **Vue UI**: `http://<pi-ip>/new/`
- **React UI**: `http://<pi-ip>/react/`

## Test Plan

- [ ] Fresh TeslaUSB install includes React UI at `/react/`
- [ ] Music sync shows real-time progress in web UI
- [ ] Existing stats2 parsing still works correctly
- [ ] All three UIs accessible and functional