### PR TITLE
Add configurable SavedClips minute window for archiving

### DIFF
--- a/doc/SetupRClone.md
+++ b/doc/SetupRClone.md
@@ -18,10 +18,12 @@ The easiest way to to configure teslausb for rclone is:
 - add the RCLONE_DRIVE and RCLONE_PATH variables to the config, according to the values you used when you configured the rclone remote.
   RCLONE_DRIVE should be a name shown by `rclone listremotes`, and RCLONE_PATH should be a path that exists on the named remote, i.e. `rclone ls "$RCLONE_DRIVE:$RCLONE_PATH"` should not print an error (but it may print nothing, if the path is newly created and currently empty).
 - optionally populate RCLONE_FLAGS with flags to add to the command, i.e. RCLONE_FLAGS=(--checksum). To specify multiple flags: RCLONE_FLAGS=(--flag1 --flag2)
+- optionally set ARCHIVE_SAVEDCLIPS_MINUTES to keep only the latest N minutes of each SavedClips event when archiving (for example, 3 to keep the last 3 minutes)
   ```
   export RCLONE_DRIVE="remotename"
   export RCLONE_PATH="remotepathname"
   export RCLONE_FLAGS=()
+  export ARCHIVE_SAVEDCLIPS_MINUTES=3
   ```
 - run `/root/bin/setup-teslausb`
 

--- a/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
+++ b/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
@@ -82,6 +82,11 @@ export SHARE_PASSWORD='password'
 #export ARCHIVE_SAVEDCLIPS=false
 #export ARCHIVE_SENTRYCLIPS=false
 #export ARCHIVE_TRACKMODECLIPS=false
+#
+# Optionally limit SavedClips uploads to only the latest N minutes per event.
+# This keeps the tail end of each saved dashcam clip (for example, 3 minutes)
+# to reduce upload time and cloud storage usage.
+#export ARCHIVE_SAVEDCLIPS_MINUTES=3
 
 # Notes on sd card and image sizes:
 #   * A 128 GB or larger sd card (or USB drive, when using Pi4) is recommended.

--- a/run/archiveloop
+++ b/run/archiveloop
@@ -387,13 +387,18 @@ for line in lines:
     parts = line.split("/", 2)
     event_key = "/".join(parts[:2]) if len(parts) >= 2 else "SavedClips"
 
-    match = timestamp_pattern.search(line)
-    if not match:
+    matches = timestamp_pattern.findall(line)
+    if not matches:
         entries.append((line, event_key, None))
         continue
 
+    # SavedClips paths contain two timestamps:
+    #   SavedClips/<event_timestamp>/<clip_timestamp>-*.mp4
+    # We must use the clip timestamp (last match), not the event folder timestamp.
+    clip_timestamp = matches[-1]
+
     try:
-        timestamp = int(datetime.datetime.strptime(match.group(1), "%Y-%m-%d_%H-%M-%S").replace(tzinfo=datetime.timezone.utc).timestamp())
+        timestamp = int(datetime.datetime.strptime(clip_timestamp, "%Y-%m-%d_%H-%M-%S").replace(tzinfo=datetime.timezone.utc).timestamp())
     except ValueError:
         entries.append((line, event_key, None))
         continue

--- a/run/archiveloop
+++ b/run/archiveloop
@@ -342,6 +342,98 @@ function intersect {
   mv /tmp/prune_tmp.$$ "$1"
 }
 
+function limit_savedclips_minutes {
+  local -r list_file="$1"
+  local -r limit_minutes="${ARCHIVE_SAVEDCLIPS_MINUTES:-}"
+
+  if [ -z "${limit_minutes}" ]
+  then
+    return
+  fi
+
+  if ! [[ "${limit_minutes}" =~ ^[0-9]+$ ]]
+  then
+    log "Ignoring ARCHIVE_SAVEDCLIPS_MINUTES='${limit_minutes}' (must be a positive integer)"
+    return
+  fi
+
+  if [ "${limit_minutes}" -lt 1 ]
+  then
+    log "Ignoring ARCHIVE_SAVEDCLIPS_MINUTES='${limit_minutes}' (must be >= 1)"
+    return
+  fi
+
+  local dropped_count
+  if ! dropped_count=$(python3 - "$list_file" "$limit_minutes" <<'PY'
+import datetime
+import re
+import sys
+
+list_path = sys.argv[1]
+limit_minutes = int(sys.argv[2])
+timestamp_pattern = re.compile(r"(\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2})")
+
+with open(list_path, encoding="utf-8", errors="ignore") as infile:
+    lines = [line.rstrip("\n") for line in infile]
+
+entries = []
+max_timestamp_by_event = {}
+
+for line in lines:
+    if not line.startswith("SavedClips/"):
+        entries.append((line, None, None))
+        continue
+
+    parts = line.split("/", 2)
+    event_key = "/".join(parts[:2]) if len(parts) >= 2 else "SavedClips"
+
+    match = timestamp_pattern.search(line)
+    if not match:
+        entries.append((line, event_key, None))
+        continue
+
+    try:
+        timestamp = int(datetime.datetime.strptime(match.group(1), "%Y-%m-%d_%H-%M-%S").replace(tzinfo=datetime.timezone.utc).timestamp())
+    except ValueError:
+        entries.append((line, event_key, None))
+        continue
+
+    entries.append((line, event_key, timestamp))
+    previous = max_timestamp_by_event.get(event_key)
+    if previous is None or timestamp > previous:
+        max_timestamp_by_event[event_key] = timestamp
+
+keep_lines = []
+dropped = 0
+
+for line, event_key, timestamp in entries:
+    if event_key is None or timestamp is None:
+        keep_lines.append(line)
+        continue
+
+    cutoff = max_timestamp_by_event[event_key] - ((limit_minutes - 1) * 60)
+    if timestamp >= cutoff:
+        keep_lines.append(line)
+    else:
+        dropped += 1
+
+with open(list_path, "w", encoding="utf-8") as outfile:
+    for line in keep_lines:
+        outfile.write(f"{line}\n")
+
+print(dropped)
+PY
+); then
+    log "Failed to enforce ARCHIVE_SAVEDCLIPS_MINUTES=${limit_minutes}; continuing with full SavedClips set"
+    return
+  fi
+
+  if [ "$dropped_count" -gt 0 ]
+  then
+    log "Pruned ${dropped_count} SavedClips file(s) older than the last ${limit_minutes} minute(s) per event."
+  fi
+}
+
 function clean_cam_mount {
 
   local mode="${1:-}"
@@ -501,6 +593,9 @@ function archive_teslacam_clips () {
 
   # apply custom removals/additions
   filterfile "${sentrylist}"
+
+  # Optionally keep only the latest N minutes of each SavedClips event.
+  limit_savedclips_minutes "${sentrylist}"
 
   local -r sentry_count=$(grep -c -v TeslaTrackMode "$sentrylist")
   local -r trackmode_count=$(grep -c TeslaTrackMode "$sentrylist")

--- a/run/archiveloop
+++ b/run/archiveloop
@@ -371,7 +371,7 @@ import sys
 
 list_path = sys.argv[1]
 limit_minutes = int(sys.argv[2])
-timestamp_pattern = re.compile(r"(\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2})")
+clip_timestamp_pattern = re.compile(r"^(\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2})(?:-(?:back|front|left_pillar|left_repeater|right_pillar|right_repeater))?\.mp4$")
 
 with open(list_path, encoding="utf-8", errors="ignore") as infile:
     lines = [line.rstrip("\n") for line in infile]
@@ -387,18 +387,14 @@ for line in lines:
     parts = line.split("/", 2)
     event_key = "/".join(parts[:2]) if len(parts) >= 2 else "SavedClips"
 
-    matches = timestamp_pattern.findall(line)
-    if not matches:
+    filename = line.rsplit("/", 1)[-1]
+    match = clip_timestamp_pattern.match(filename)
+    if not match:
         entries.append((line, event_key, None))
         continue
 
-    # SavedClips paths contain two timestamps:
-    #   SavedClips/<event_timestamp>/<clip_timestamp>-*.mp4
-    # We must use the clip timestamp (last match), not the event folder timestamp.
-    clip_timestamp = matches[-1]
-
     try:
-        timestamp = int(datetime.datetime.strptime(clip_timestamp, "%Y-%m-%d_%H-%M-%S").replace(tzinfo=datetime.timezone.utc).timestamp())
+        timestamp = int(datetime.datetime.strptime(match.group(1), "%Y-%m-%d_%H-%M-%S").replace(tzinfo=datetime.timezone.utc).timestamp())
     except ValueError:
         entries.append((line, event_key, None))
         continue


### PR DESCRIPTION
## Summary
- add optional `ARCHIVE_SAVEDCLIPS_MINUTES` to limit how much of each `SavedClips` event is uploaded
- keep only the newest **N minutes** of clip files per SavedClips event before archive transfer
- preserve non-clip files (for example `event.json` / thumbnails)
- document the setting in:
  - `pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample`
  - `doc/SetupRClone.md`

## Why
By default, all clips in each SavedClips event are uploaded. This option reduces upload time and cloud storage when only the tail of each event is needed.

## Config
Example:

```bash
export ARCHIVE_SAVEDCLIPS_MINUTES=3
```

Behavior:
- unset or invalid value: existing behavior (no SavedClips minute pruning)
- positive integer: retain only the latest N-minute window of SavedClips clip files per event

## Implementation details
- pruning is applied in `run/archiveloop` before `archive-clips.sh`
- timestamp parsing uses strict clip filename matching (`YYYY-MM-DD_HH-MM-SS-<camera>.mp4`) to avoid path-level ambiguity

## Validation
- `bash -n run/archiveloop`
- Python snippet compile check (embedded limiter)
- behavior test with 6 one-minute clips + `ARCHIVE_SAVEDCLIPS_MINUTES=3` kept only the latest 3 minutes
