### PR TITLE
Add optional SavedClips minute-window filter

### DIFF
--- a/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
+++ b/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
@@ -84,9 +84,9 @@ export SHARE_PASSWORD='password'
 #export ARCHIVE_TRACKMODECLIPS=false
 
 # Optional: archive only the last N minutes of footage from each SavedClips
-# event folder. Default is 0 (archive all SavedClips footage).
-# Example: set to 3 to upload only the last ~3 minutes of each Saved event.
-#export ARCHIVE_SAVEDCLIPS_LAST_MINUTES=3
+# event folder. Default is 3 minutes for new installs.
+# Set to 0 to archive all SavedClips footage instead.
+export ARCHIVE_SAVEDCLIPS_LAST_MINUTES=3
 
 # Notes on sd card and image sizes:
 #   * A 128 GB or larger sd card (or USB drive, when using Pi4) is recommended.

--- a/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
+++ b/pi-gen-sources/00-teslausb-tweaks/files/teslausb_setup_variables.conf.sample
@@ -83,6 +83,11 @@ export SHARE_PASSWORD='password'
 #export ARCHIVE_SENTRYCLIPS=false
 #export ARCHIVE_TRACKMODECLIPS=false
 
+# Optional: archive only the last N minutes of footage from each SavedClips
+# event folder. Default is 0 (archive all SavedClips footage).
+# Example: set to 3 to upload only the last ~3 minutes of each Saved event.
+#export ARCHIVE_SAVEDCLIPS_LAST_MINUTES=3
+
 # Notes on sd card and image sizes:
 #   * A 128 GB or larger sd card (or USB drive, when using Pi4) is recommended.
 #     The minimum supported size is 64 GB.

--- a/run/archiveloop
+++ b/run/archiveloop
@@ -504,12 +504,14 @@ function archive_teslacam_clips () {
 
   # Optional: archive only the last N minutes of SavedClips footage for each
   # SavedClips event folder. 0 keeps existing behavior (archive all).
+  local -r savedclips_removed_by_window=/tmp/savedclips_removed_by_window
+  true > "${savedclips_removed_by_window}"
   local -r archive_savedclips_last_minutes=${ARCHIVE_SAVEDCLIPS_LAST_MINUTES:-0}
   if [[ "${archive_savedclips_last_minutes}" =~ ^[0-9]+$ ]] && [ "${archive_savedclips_last_minutes}" -gt 0 ]
   then
     if command -v python3 > /dev/null
     then
-      python3 /root/bin/filter_savedclips_window.py --list "${sentrylist}" --minutes "${archive_savedclips_last_minutes}" ||         log "SavedClips minute-window filter failed, continuing without it"
+      python3 /root/bin/filter_savedclips_window.py --list "${sentrylist}" --minutes "${archive_savedclips_last_minutes}" --removed-list "${savedclips_removed_by_window}" ||         log "SavedClips minute-window filter failed, continuing without it"
     else
       log "python3 not available, skipping SavedClips minute-window filter"
     fi
@@ -609,6 +611,12 @@ function archive_teslacam_clips () {
         echo "$line" >> "${sentrylist_archived}"
       fi
     done < ${sentrylist}
+
+    if [ -s "${savedclips_removed_by_window}" ]
+    then
+      cat "${savedclips_removed_by_window}" >> "${sentrylist_archived}"
+      sortfile "${sentrylist_archived}"
+    fi
 
     # copy the list of archived files back to /mutable if it has changed
     if ! diff -q -N "${sentrylist_archived}" "${sentrylist_previously_archived}" > /dev/null

--- a/run/archiveloop
+++ b/run/archiveloop
@@ -502,6 +502,22 @@ function archive_teslacam_clips () {
   # apply custom removals/additions
   filterfile "${sentrylist}"
 
+  # Optional: archive only the last N minutes of SavedClips footage for each
+  # SavedClips event folder. 0 keeps existing behavior (archive all).
+  local -r archive_savedclips_last_minutes=${ARCHIVE_SAVEDCLIPS_LAST_MINUTES:-0}
+  if [[ "${archive_savedclips_last_minutes}" =~ ^[0-9]+$ ]] && [ "${archive_savedclips_last_minutes}" -gt 0 ]
+  then
+    if command -v python3 > /dev/null
+    then
+      python3 /root/bin/filter_savedclips_window.py --list "${sentrylist}" --minutes "${archive_savedclips_last_minutes}" ||         log "SavedClips minute-window filter failed, continuing without it"
+    else
+      log "python3 not available, skipping SavedClips minute-window filter"
+    fi
+  elif ! [[ "${archive_savedclips_last_minutes}" =~ ^[0-9]+$ ]]
+  then
+    log "Invalid ARCHIVE_SAVEDCLIPS_LAST_MINUTES=${archive_savedclips_last_minutes}, expected a non-negative integer"
+  fi
+
   local -r sentry_count=$(grep -c -v TeslaTrackMode "$sentrylist")
   local -r trackmode_count=$(grep -c TeslaTrackMode "$sentrylist")
   local -r ignore_count=$(wc -l < "$ignorelist")

--- a/run/filter_savedclips_window.py
+++ b/run/filter_savedclips_window.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Prune SavedClips entries older than N minutes from each event folder.
+
+Input list format is one relative path per line (same as sentry_files):
+  SavedClips/<event-folder>/<filename>
+
+For each SavedClips event folder, this script finds clip timestamps from filenames
+matching Tesla's naming pattern: YYYY-MM-DD_HH-MM-SS-*.{mp4,MP4}.
+It keeps only files whose clip timestamp is within N minutes of the latest
+clip timestamp in that same event folder.
+
+Non-SavedClips entries are preserved.
+SavedClips entries with no parseable timestamp are preserved.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import re
+from pathlib import PurePosixPath
+
+TIMESTAMP_RE = re.compile(r"^(\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2})-")
+
+
+def parse_clip_ts(filename: str) -> dt.datetime | None:
+    match = TIMESTAMP_RE.match(filename)
+    if not match:
+        return None
+    try:
+        return dt.datetime.strptime(match.group(1), "%Y-%m-%d_%H-%M-%S")
+    except ValueError:
+        return None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--list", required=True, help="Path to sentry_files list")
+    parser.add_argument(
+        "--minutes",
+        type=int,
+        required=True,
+        help="Minutes of SavedClips footage to keep per event folder",
+    )
+    args = parser.parse_args()
+
+    if args.minutes < 0:
+        raise SystemExit("--minutes must be >= 0")
+
+    list_path = args.list
+    with open(list_path, "r", encoding="utf-8") as f:
+        lines = [line.rstrip("\n") for line in f]
+
+    if args.minutes == 0:
+        return 0
+
+    max_ts_by_event: dict[str, dt.datetime] = {}
+    parsed_ts_by_path: dict[str, dt.datetime] = {}
+
+    for relpath in lines:
+        path = PurePosixPath(relpath)
+        if len(path.parts) < 3 or path.parts[0] != "SavedClips":
+            continue
+
+        ts = parse_clip_ts(path.name)
+        if ts is None:
+            continue
+
+        event_key = "/".join(path.parts[:2])
+        parsed_ts_by_path[relpath] = ts
+        cur_max = max_ts_by_event.get(event_key)
+        if cur_max is None or ts > cur_max:
+            max_ts_by_event[event_key] = ts
+
+    out_lines: list[str] = []
+    for relpath in lines:
+        path = PurePosixPath(relpath)
+
+        if len(path.parts) < 3 or path.parts[0] != "SavedClips":
+            out_lines.append(relpath)
+            continue
+
+        ts = parsed_ts_by_path.get(relpath)
+        if ts is None:
+            # Keep non-clip/non-standard files to avoid data loss.
+            out_lines.append(relpath)
+            continue
+
+        event_key = "/".join(path.parts[:2])
+        max_ts = max_ts_by_event.get(event_key)
+        if max_ts is None:
+            out_lines.append(relpath)
+            continue
+
+        cutoff = max_ts - dt.timedelta(minutes=args.minutes)
+        if ts >= cutoff:
+            out_lines.append(relpath)
+
+    with open(list_path, "w", encoding="utf-8") as f:
+        for line in out_lines:
+            f.write(f"{line}\n")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/run/filter_savedclips_window.py
+++ b/run/filter_savedclips_window.py
@@ -42,6 +42,10 @@ def main() -> int:
         required=True,
         help="Minutes of SavedClips footage to keep per event folder",
     )
+    parser.add_argument(
+        "--removed-list",
+        help="Optional path to write filtered-out SavedClips entries",
+    )
     args = parser.parse_args()
 
     if args.minutes < 0:
@@ -51,7 +55,12 @@ def main() -> int:
     with open(list_path, "r", encoding="utf-8") as f:
         lines = [line.rstrip("\n") for line in f]
 
+    removed_lines: list[str] = []
     if args.minutes == 0:
+        if args.removed_list:
+            with open(args.removed_list, "w", encoding="utf-8") as f:
+                for line in removed_lines:
+                    f.write(f"{line}\n")
         return 0
 
     max_ts_by_event: dict[str, dt.datetime] = {}
@@ -95,10 +104,17 @@ def main() -> int:
         cutoff = max_ts - dt.timedelta(minutes=args.minutes)
         if ts >= cutoff:
             out_lines.append(relpath)
+        else:
+            removed_lines.append(relpath)
 
     with open(list_path, "w", encoding="utf-8") as f:
         for line in out_lines:
             f.write(f"{line}\n")
+
+    if args.removed_list:
+        with open(args.removed_list, "w", encoding="utf-8") as f:
+            for line in removed_lines:
+                f.write(f"{line}\n")
 
     return 0
 

--- a/setup/pi/configure.sh
+++ b/setup/pi/configure.sh
@@ -370,6 +370,7 @@ function install_archive_scripts () {
   copy_script run/remountfs_rw "$install_path"
   copy_script run/awake_start "$install_path"
   copy_script run/awake_stop "$install_path"
+  copy_script run/filter_savedclips_window.py "$install_path"
   log_progress "Installing archive module scripts"
   copy_script "$archive_module"/verify-and-configure-archive.sh /tmp
   copy_script "$archive_module"/archive-clips.sh "$install_path"

--- a/tests/filter-savedclips-window-test.sh
+++ b/tests/filter-savedclips-window-test.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT="$(cd "$(dirname "$0")/.." && pwd)/run/filter_savedclips_window.py"
+TMPDIR="$(mktemp -d)"
+LIST="$TMPDIR/sentry_files"
+EXP="$TMPDIR/expected"
+
+cleanup() {
+  rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+cat > "$LIST" <<DATA
+SavedClips/2026-01-01_12-00-00/2026-01-01_12-00-00-front.mp4
+SavedClips/2026-01-01_12-00-00/2026-01-01_12-01-00-front.mp4
+SavedClips/2026-01-01_12-00-00/2026-01-01_12-05-00-front.mp4
+SavedClips/2026-01-01_12-00-00/event.json
+SavedClips/2026-01-01_13-00-00/2026-01-01_13-00-00-front.mp4
+SavedClips/2026-01-01_13-00-00/2026-01-01_13-02-00-front.mp4
+SentryClips/2026-01-01_12-00-00/2026-01-01_12-00-00-front.mp4
+DATA
+
+python3 "$SCRIPT" --list "$LIST" --minutes 3
+
+cat > "$EXP" <<DATA
+SavedClips/2026-01-01_12-00-00/2026-01-01_12-05-00-front.mp4
+SavedClips/2026-01-01_12-00-00/event.json
+SavedClips/2026-01-01_13-00-00/2026-01-01_13-00-00-front.mp4
+SavedClips/2026-01-01_13-00-00/2026-01-01_13-02-00-front.mp4
+SentryClips/2026-01-01_12-00-00/2026-01-01_12-00-00-front.mp4
+DATA
+
+diff -u "$EXP" "$LIST"
+
+echo "filter-savedclips-window-test: OK"

--- a/tests/filter-savedclips-window-test.sh
+++ b/tests/filter-savedclips-window-test.sh
@@ -5,6 +5,8 @@ SCRIPT="$(cd "$(dirname "$0")/.." && pwd)/run/filter_savedclips_window.py"
 TMPDIR="$(mktemp -d)"
 LIST="$TMPDIR/sentry_files"
 EXP="$TMPDIR/expected"
+REMOVED="$TMPDIR/removed"
+EXP_REMOVED="$TMPDIR/expected_removed"
 
 cleanup() {
   rm -rf "$TMPDIR"
@@ -21,7 +23,7 @@ SavedClips/2026-01-01_13-00-00/2026-01-01_13-02-00-front.mp4
 SentryClips/2026-01-01_12-00-00/2026-01-01_12-00-00-front.mp4
 DATA
 
-python3 "$SCRIPT" --list "$LIST" --minutes 3
+python3 "$SCRIPT" --list "$LIST" --minutes 3 --removed-list "$REMOVED"
 
 cat > "$EXP" <<DATA
 SavedClips/2026-01-01_12-00-00/2026-01-01_12-05-00-front.mp4
@@ -31,6 +33,12 @@ SavedClips/2026-01-01_13-00-00/2026-01-01_13-02-00-front.mp4
 SentryClips/2026-01-01_12-00-00/2026-01-01_12-00-00-front.mp4
 DATA
 
+cat > "$EXP_REMOVED" <<DATA
+SavedClips/2026-01-01_12-00-00/2026-01-01_12-00-00-front.mp4
+SavedClips/2026-01-01_12-00-00/2026-01-01_12-01-00-front.mp4
+DATA
+
 diff -u "$EXP" "$LIST"
+diff -u "$EXP_REMOVED" "$REMOVED"
 
 echo "filter-savedclips-window-test: OK"


### PR DESCRIPTION
This adds an optional setting to limit how much SavedClips footage is archived per event.

## What is added
- New config variable: `ARCHIVE_SAVEDCLIPS_LAST_MINUTES` (default `0`)
  - `0` keeps existing behavior (archive all SavedClips)
  - `N > 0` archives only the last `N` minutes of clip files from each `SavedClips/<event>/` folder
- New helper script: `run/filter_savedclips_window.py`
  - Parses Tesla clip timestamps from filenames
  - Applies the minute window per SavedClips event folder
  - Keeps non-SavedClips entries untouched
- Wiring in `run/archiveloop` to call the helper when enabled
- Documentation update in `teslausb_setup_variables.conf.sample`

## Why
This allows users to reduce cloud upload time and storage by syncing only the most recent part of manually saved dashcam events (for example, last 3 minutes instead of full event clips).
