### PR TITLE
Add static IP fallback for time synchronization

### DIFF
--- a/run/archiveloop
+++ b/run/archiveloop
@@ -716,7 +716,7 @@ function set_time () {
   local -r clocktime_start=$(date +%s.%N)
   for _ in {1..5}
   do
-    if ntpdig -S time.google.com || ntpdig -S 129.6.15.28 #(time-a-g.nist.gov)
+    if sntp -S time.google.com || ntpdig -S time.google.com || sntp -S 129.6.15.28 || ntpdig -S 129.6.15.28 #(time-a-g.nist.gov)
     then
       local -r uptime_end=$(awk '{print $1}' /proc/uptime)
       local -r clocktime_end=$(date +%s.%N)

--- a/run/archiveloop
+++ b/run/archiveloop
@@ -716,14 +716,14 @@ function set_time () {
   local -r clocktime_start=$(date +%s.%N)
   for _ in {1..5}
   do
-    if sntp -S time.google.com || ntpdig -S time.google.com
+    if ntpdig -S time.google.com || ntpdig -S 129.6.15.28 #(time-a-g.nist.gov)
     then
       local -r uptime_end=$(awk '{print $1}' /proc/uptime)
       local -r clocktime_end=$(date +%s.%N)
       log "$(awk "BEGIN {printf \"Time adjusted by %f seconds after %f seconds\", $clocktime_end-$clocktime_start, $uptime_end-$uptime_start}")"
       return
     fi
-    log "sntp failed, retrying..."
+    log "ntpdig failed, retrying..."
     sleep 2
   done
   log "Failed to set time"


### PR DESCRIPTION
Add a static IP fallback for time synchronization. I found that if it boots with a date so wrong that DNS does not work, but syncing with a static IP works. 