### PR TITLE
Fix unauthenticated endpoints

### DIFF
--- a/teslausb-www/teslausb.nginx
+++ b/teslausb-www/teslausb.nginx
@@ -26,6 +26,8 @@ server {
          fastcgi_max_temp_file_size 0;
     }
     location /TeslaCam/ {
+         auth_basic off;
+         auth_basic_user_file /etc/nginx/.htpasswd;
          root /var/www/html;
          fancyindex on;
          fancyindex_css_href /fancyindex.css;

--- a/teslausb-www/teslausb.nginx
+++ b/teslausb-www/teslausb.nginx
@@ -18,6 +18,8 @@ server {
     }
 
     location /cgi-bin/ {
+         auth_basic off;
+         auth_basic_user_file /etc/nginx/.htpasswd;
          gzip off;
          root /var/www/html;
          fastcgi_pass  unix:/var/run/fcgiwrap.socket;


### PR DESCRIPTION
Added authentication to /cgi-bin and /TeslaCam. Previously, anyone with network access could access clips and trigger actions within cgi-bin.